### PR TITLE
add CSP to security_solution  as a sub-plugin with blank routes

### DIFF
--- a/x-pack/plugins/security_solution/common/constants.ts
+++ b/x-pack/plugins/security_solution/common/constants.ts
@@ -101,6 +101,11 @@ export enum SecurityPageName {
   trustedApps = 'trusted_apps',
   ueba = 'ueba',
   uncommonProcesses = 'uncommon_processes',
+  cloud_posture = 'cloud_posture',
+  cloud_posture_dashboard = 'cloud_posture_dashboard',
+  cloud_posture_rules = 'cloud_posture_rules',
+  cloud_posture_alerts = 'cloud_posture_alerts',
+  cloud_posture_findings = 'cloud_posture_findings',
 }
 
 export const TIMELINES_PATH = '/timelines';
@@ -135,6 +140,12 @@ export const APP_ENDPOINTS_PATH = `${APP_PATH}${ENDPOINTS_PATH}`;
 export const APP_TRUSTED_APPS_PATH = `${APP_PATH}${TRUSTED_APPS_PATH}`;
 export const APP_EVENT_FILTERS_PATH = `${APP_PATH}${EVENT_FILTERS_PATH}`;
 export const APP_HOST_ISOLATION_EXCEPTIONS_PATH = `${APP_PATH}${HOST_ISOLATION_EXCEPTIONS_PATH}`;
+
+export const CLOUD_POSTURE = '/cloud_posture';
+export const CLOUD_POSTURE_RULES = `${APP_PATH}${CLOUD_POSTURE}_rules` as const;
+export const CLOUD_POSTURE_ALERTS = `${APP_PATH}${CLOUD_POSTURE}_alerts` as const;
+export const CLOUD_POSTURE_FINDINGS = `${APP_PATH}${CLOUD_POSTURE}_findings` as const;
+export const CLOUD_POSTURE_DASHBOARD = `${APP_PATH}${CLOUD_POSTURE}_dashboard` as const;
 
 /** The comma-delimited list of Elasticsearch indices from which the SIEM app collects events */
 export const DEFAULT_INDEX_PATTERN = [

--- a/x-pack/plugins/security_solution/public/app/deep_links/index.ts
+++ b/x-pack/plugins/security_solution/public/app/deep_links/index.ts
@@ -50,6 +50,11 @@ import {
   UEBA_PATH,
   CASES_FEATURE_ID,
   HOST_ISOLATION_EXCEPTIONS_PATH,
+  CLOUD_POSTURE,
+  CLOUD_POSTURE_RULES,
+  CLOUD_POSTURE_FINDINGS,
+  CLOUD_POSTURE_DASHBOARD,
+  CLOUD_POSTURE_ALERTS,
 } from '../../../common/constants';
 import { ExperimentalFeatures } from '../../../common/experimental_features';
 
@@ -337,6 +342,38 @@ export const securitySolutionsDeepLinks: AppDeepLink[] = [
         id: SecurityPageName.hostIsolationExceptions,
         title: HOST_ISOLATION_EXCEPTIONS,
         path: HOST_ISOLATION_EXCEPTIONS_PATH,
+      },
+    ],
+  },
+  {
+    id: SecurityPageName.cloud_posture,
+    title: 'Cloud Posture',
+    path: CLOUD_POSTURE,
+    // navLinkStatus: AppNavLinkStatus.hidden,
+    deepLinks: [
+      {
+        id: SecurityPageName.cloud_posture_dashboard,
+        title: 'Dashboard',
+        // eslint-disable-next-line prettier/prettier
+        path: '/cloud_posture_dashboard',
+      },
+      {
+        id: SecurityPageName.cloud_posture_rules,
+        title: 'Rules',
+        // eslint-disable-next-line prettier/prettier
+        path: '/cloud_posture_rules',
+      },
+      {
+        id: SecurityPageName.cloud_posture_alerts,
+        title: 'Alerts',
+        // eslint-disable-next-line prettier/prettier
+        path: '/cloud_posture_alerts',
+      },
+      {
+        id: SecurityPageName.cloud_posture_findings,
+        title: 'Findings',
+        // eslint-disable-next-line prettier/prettier
+        path: '/cloud_posture_findings',
       },
     ],
   },

--- a/x-pack/plugins/security_solution/public/app/home/home_navigations.ts
+++ b/x-pack/plugins/security_solution/public/app/home/home_navigations.ts
@@ -27,6 +27,10 @@ import {
   APP_UEBA_PATH,
   SecurityPageName,
   APP_HOST_ISOLATION_EXCEPTIONS_PATH,
+  CLOUD_POSTURE_DASHBOARD,
+  CLOUD_POSTURE_RULES,
+  CLOUD_POSTURE_ALERTS,
+  CLOUD_POSTURE_FINDINGS,
 } from '../../../common/constants';
 
 export const navTabs: SecurityNav = {
@@ -128,6 +132,34 @@ export const navTabs: SecurityNav = {
     disabled: false,
     urlKey: 'administration',
   },
+  [SecurityPageName.cloud_posture_dashboard]: {
+    id: SecurityPageName.cloud_posture_dashboard,
+    name: i18n.CLOUD_POSTURE_DASHBOARD,
+    href: CLOUD_POSTURE_DASHBOARD,
+    disabled: false,
+    urlKey: 'administration',
+  },
+  [SecurityPageName.cloud_posture_rules]: {
+    id: SecurityPageName.cloud_posture_rules,
+    name: i18n.RULES,
+    href: CLOUD_POSTURE_RULES,
+    disabled: false,
+    urlKey: 'administration',
+  },
+  [SecurityPageName.cloud_posture_alerts]: {
+    id: SecurityPageName.cloud_posture_alerts,
+    name: i18n.ALERTS,
+    href: CLOUD_POSTURE_ALERTS,
+    disabled: false,
+    urlKey: 'administration',
+  },
+  [SecurityPageName.cloud_posture_findings]: {
+    id: SecurityPageName.cloud_posture_findings,
+    name: i18n.FINDINGS,
+    href: CLOUD_POSTURE_FINDINGS,
+    disabled: false,
+    urlKey: 'administration',
+  },
 };
 
 export const securityNavGroup: SecurityNavGroup = {
@@ -146,5 +178,9 @@ export const securityNavGroup: SecurityNavGroup = {
   [SecurityNavGroupKey.manage]: {
     id: SecurityNavGroupKey.manage,
     name: i18n.MANAGE,
+  },
+  [SecurityNavGroupKey.cloud_posture]: {
+    id: SecurityNavGroupKey.cloud_posture,
+    name: i18n.CLOUD_POSTURE,
   },
 };

--- a/x-pack/plugins/security_solution/public/app/index.tsx
+++ b/x-pack/plugins/security_solution/public/app/index.tsx
@@ -48,6 +48,7 @@ export const renderApp = ({
             ...subPlugins.timelines.routes,
             ...subPlugins.cases.routes,
             ...subPlugins.management.routes,
+            ...subPlugins.cloud_posture.routes,
           ].map((route, index) => (
             <Route key={`route-${index}`} {...route} />
           ))}

--- a/x-pack/plugins/security_solution/public/app/translations.ts
+++ b/x-pack/plugins/security_solution/public/app/translations.ts
@@ -80,3 +80,13 @@ export const INVESTIGATE = i18n.translate('xpack.securitySolution.navigation.inv
 export const MANAGE = i18n.translate('xpack.securitySolution.navigation.manage', {
   defaultMessage: 'Manage',
 });
+export const CLOUD_POSTURE = i18n.translate('xpack.securitySolution.navigation.cloud_posture', {
+  defaultMessage: 'Cloud Posture',
+});
+export const FINDINGS = i18n.translate('xpack.securitySolution.navigation.findings', {
+  defaultMessage: 'Findings',
+});
+export const CLOUD_POSTURE_DASHBOARD = i18n.translate(
+  'xpack.securitySolution.navigation.dashboard',
+  { defaultMessage: 'Dashboard' }
+);

--- a/x-pack/plugins/security_solution/public/cloud_posture/index.ts
+++ b/x-pack/plugins/security_solution/public/cloud_posture/index.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { Storage } from '../../../../../src/plugins/kibana_utils/public';
+import { getTimelinesInStorageByIds } from '../timelines/containers/local_storage';
+import { TimelineIdLiteral, TimelineId } from '../../common/types/timeline';
+import { routes } from './routes';
+import { SecuritySubPlugin } from '../app/types';
+
+export const DETECTIONS_TIMELINE_IDS: TimelineIdLiteral[] = [
+  TimelineId.detectionsRulesDetailsPage,
+  TimelineId.detectionsPage,
+];
+
+export class CloudPosture {
+  public setup() {}
+
+  public start(storage: Storage, core: any, plugins: any): SecuritySubPlugin {
+    // public start(storage: Storage, core: CoreStart, plugins: StartPlugins): SecuritySubPlugin {
+    return {
+      storageTimelines: {
+        timelineById: getTimelinesInStorageByIds(storage, DETECTIONS_TIMELINE_IDS),
+      },
+      routes,
+    };
+  }
+}

--- a/x-pack/plugins/security_solution/public/cloud_posture/pages/alerts/index.tsx
+++ b/x-pack/plugins/security_solution/public/cloud_posture/pages/alerts/index.tsx
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiSpacer } from '@elastic/eui';
+import { SecuritySolutionPageWrapper } from '../../../common/components/page_wrapper';
+import { HeaderPage } from '../../../common/components/header_page';
+
+export const Alerts = () => {
+  return (
+    <SecuritySolutionPageWrapper noPadding={false} data-test-subj="csp_rules">
+      <HeaderPage hideSourcerer border title={'Alerts'} />
+
+      <EuiSpacer />
+    </SecuritySolutionPageWrapper>
+  );
+};

--- a/x-pack/plugins/security_solution/public/cloud_posture/pages/dashboard/index.tsx
+++ b/x-pack/plugins/security_solution/public/cloud_posture/pages/dashboard/index.tsx
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiSpacer } from '@elastic/eui';
+import { SecuritySolutionPageWrapper } from '../../../common/components/page_wrapper';
+import { HeaderPage } from '../../../common/components/header_page';
+
+export const Dashboard = () => {
+  return (
+    <SecuritySolutionPageWrapper noPadding={false} data-test-subj="csp_rules">
+      <HeaderPage hideSourcerer border title={'Dashboard'} />
+
+      <EuiSpacer />
+    </SecuritySolutionPageWrapper>
+  );
+};

--- a/x-pack/plugins/security_solution/public/cloud_posture/pages/findings/index.tsx
+++ b/x-pack/plugins/security_solution/public/cloud_posture/pages/findings/index.tsx
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiSpacer } from '@elastic/eui';
+import { SecuritySolutionPageWrapper } from '../../../common/components/page_wrapper';
+import { HeaderPage } from '../../../common/components/header_page';
+
+export const Findings = () => {
+  return (
+    <SecuritySolutionPageWrapper noPadding={false} data-test-subj="csp_rules">
+      <HeaderPage hideSourcerer border title={'Findings'} />
+
+      <EuiSpacer />
+    </SecuritySolutionPageWrapper>
+  );
+};

--- a/x-pack/plugins/security_solution/public/cloud_posture/pages/rules/index.tsx
+++ b/x-pack/plugins/security_solution/public/cloud_posture/pages/rules/index.tsx
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiSpacer } from '@elastic/eui';
+import { SecuritySolutionPageWrapper } from '../../../common/components/page_wrapper';
+import { HeaderPage } from '../../../common/components/header_page';
+
+export const Rules = () => {
+  return (
+    <SecuritySolutionPageWrapper noPadding={false} data-test-subj="csp_rules">
+      <HeaderPage hideSourcerer border title={'Rules'} />
+
+      <EuiSpacer />
+    </SecuritySolutionPageWrapper>
+  );
+};

--- a/x-pack/plugins/security_solution/public/cloud_posture/routes.tsx
+++ b/x-pack/plugins/security_solution/public/cloud_posture/routes.tsx
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+/* eslint-disable prefer-template */
+/* eslint-disable react/display-name */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable prettier/prettier */
+
+import React from 'react';
+import { RouteProps } from 'react-router-dom';
+import { TrackApplicationView } from '../../../../../src/plugins/usage_collection/public';
+import { SecurityPageName } from '../../common/constants';
+
+import { Dashboard } from './pages/dashboard';
+import { Alerts } from './pages/alerts';
+import { Rules } from './pages/rules';
+import { Findings } from './pages/findings';
+
+export const routes: RouteProps[] = [
+  {
+    path: '/cloud_posture_dashboard',
+    render: Dashboard,
+  },
+  {
+    path: '/cloud_posture_rules',
+    render: Rules,
+  },
+  {
+    path: '/cloud_posture_alerts',
+    render: Alerts,
+  },
+  {
+    path: '/cloud_posture_findings',
+    render: Findings,
+  },
+];

--- a/x-pack/plugins/security_solution/public/common/components/navigation/types.ts
+++ b/x-pack/plugins/security_solution/public/common/components/navigation/types.ts
@@ -28,6 +28,7 @@ export enum SecurityNavGroupKey {
   explore = 'explore',
   investigate = 'investigate',
   manage = 'manage',
+  cloud_posture = 'cloud_posture',
 }
 
 export type SecurityNavGroup = Record<SecurityNavGroupKey, NavGroupTab>;
@@ -54,7 +55,11 @@ export type SecurityNavKey =
   | SecurityPageName.rules
   | SecurityPageName.timelines
   | SecurityPageName.trustedApps
-  | SecurityPageName.ueba;
+  | SecurityPageName.ueba
+  | SecurityPageName.cloud_posture_dashboard
+  | SecurityPageName.cloud_posture_rules
+  | SecurityPageName.cloud_posture_alerts
+  | SecurityPageName.cloud_posture_findings;
 
 export type SecurityNav = Record<SecurityNavKey, NavTab>;
 

--- a/x-pack/plugins/security_solution/public/common/components/navigation/use_security_solution_navigation/use_navigation_items.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/navigation/use_security_solution_navigation/use_navigation_items.tsx
@@ -34,7 +34,6 @@ export const usePrimaryNavigationItems = ({
       };
 
       const appHref = getAppUrl({ deepLinkId: id, path: urlSearch });
-
       return {
         'data-href': appHref,
         'data-test-subj': `navigation-${id}`,
@@ -64,6 +63,7 @@ export const usePrimaryNavigationItems = ({
 function usePrimaryNavigationItemsToDisplay(navTabs: Record<string, NavTab>) {
   const hasCasesReadPermissions = useGetUserCasesPermissions()?.read;
   const canSeeHostIsolationExceptions = useCanSeeHostIsolationExceptionsMenu();
+
   return useMemo(() => {
     return [
       {
@@ -90,6 +90,15 @@ function usePrimaryNavigationItemsToDisplay(navTabs: Record<string, NavTab>) {
           navTabs.trusted_apps,
           navTabs.event_filters,
           ...(canSeeHostIsolationExceptions ? [navTabs.host_isolation_exceptions] : []),
+        ],
+      },
+      {
+        ...securityNavGroup.cloud_posture,
+        items: [
+          navTabs.cloud_posture_dashboard,
+          navTabs.cloud_posture_rules,
+          navTabs.cloud_posture_alerts,
+          navTabs.cloud_posture_findings,
         ],
       },
     ];

--- a/x-pack/plugins/security_solution/public/common/components/url_state/constants.ts
+++ b/x-pack/plugins/security_solution/public/common/components/url_state/constants.ts
@@ -35,4 +35,5 @@ export type UrlStateType =
   | 'overview'
   | 'rules'
   | 'timeline'
-  | 'ueba';
+  | 'ueba'
+  | 'cloud_posture';

--- a/x-pack/plugins/security_solution/public/common/components/url_state/helpers.ts
+++ b/x-pack/plugins/security_solution/public/common/components/url_state/helpers.ts
@@ -109,6 +109,8 @@ export const getUrlType = (pageName: string): UrlStateType => {
     return 'case';
   } else if (pageName === SecurityPageName.administration) {
     return 'administration';
+  } else if (pageName === SecurityPageName.cloud_posture) {
+    return 'cloud_posture';
   }
   return 'overview';
 };

--- a/x-pack/plugins/security_solution/public/lazy_sub_plugins.tsx
+++ b/x-pack/plugins/security_solution/public/lazy_sub_plugins.tsx
@@ -24,6 +24,11 @@ import { Timelines } from './timelines';
 import { Management } from './management';
 
 /**
+ * Temporary initial cloud posture FE
+ */
+import { CloudPosture } from './cloud_posture';
+
+/**
  * The classes used to instantiate the sub plugins. These are grouped into a single object for the sake of bundling them in a single dynamic import.
  */
 const subPluginClasses = {
@@ -37,5 +42,6 @@ const subPluginClasses = {
   Rules,
   Timelines,
   Management,
+  CloudPosture,
 };
 export { subPluginClasses };

--- a/x-pack/plugins/security_solution/public/plugin.tsx
+++ b/x-pack/plugins/security_solution/public/plugin.tsx
@@ -296,6 +296,7 @@ export class Plugin implements IPlugin<PluginSetup, PluginStart, SetupPlugins, S
         overview: new subPluginClasses.Overview(),
         timelines: new subPluginClasses.Timelines(),
         management: new subPluginClasses.Management(),
+        cloud_posture: new subPluginClasses.CloudPosture(),
       };
     }
     return this._subPlugins;
@@ -321,6 +322,7 @@ export class Plugin implements IPlugin<PluginSetup, PluginStart, SetupPlugins, S
       ueba: subPlugins.ueba.start(storage),
       timelines: subPlugins.timelines.start(),
       management: subPlugins.management.start(core, plugins),
+      cloud_posture: subPlugins.cloud_posture.start(storage, core, plugins),
     };
   }
 

--- a/x-pack/plugins/security_solution/public/types.ts
+++ b/x-pack/plugins/security_solution/public/types.ts
@@ -39,6 +39,7 @@ import { Rules } from './rules';
 import { Timelines } from './timelines';
 import { Management } from './management';
 import { Ueba } from './ueba';
+import { CloudPosture } from './cloud_posture';
 import { LicensingPluginStart, LicensingPluginSetup } from '../../licensing/public';
 import { DashboardStart } from '../../../../src/plugins/dashboard/public';
 
@@ -98,6 +99,7 @@ export interface SubPlugins {
   overview: Overview;
   timelines: Timelines;
   management: Management;
+  cloud_posture: CloudPosture;
 }
 
 // TODO: find a better way to defined these types
@@ -112,4 +114,5 @@ export interface StartedSubPlugins {
   overview: ReturnType<Overview['start']>;
   timelines: ReturnType<Timelines['start']>;
   management: ReturnType<Management['start']>;
+  cloud_posture: ReturnType<CloudPosture['start']>;
 }


### PR DESCRIPTION
this PR is meant to address 2 issues: 
- https://github.com/elastic/security-team/issues/1933
- https://github.com/elastic/security-team/issues/1945

This PR creates an _initial and temporary_ entry point for integrating cloud posture FE in security solution.

it adds a folder named `cloud_posture` inside `security_solution/public` and registers a few empty routes from within a  new sub-plugin. 

same outcome can be achieved in other ways, which are also explored. 

example page:

![Screen Shot 2021-10-21 at 11 34 05](https://user-images.githubusercontent.com/20814186/138241652-11a398d7-866a-40a9-ad6a-555dbca6d846.png)


^ sidebar navigation is temporary as it's still unknown. 