### PR TITLE
CSP entry point with root sidebar nav

### DIFF
--- a/x-pack/plugins/security_solution/common/constants.ts
+++ b/x-pack/plugins/security_solution/common/constants.ts
@@ -71,6 +71,13 @@ export const DEFAULT_THREAT_INDEX_KEY = 'securitySolution:defaultThreatIndex';
 export const DEFAULT_THREAT_INDEX_VALUE = ['logs-ti_*'];
 export const DEFAULT_THREAT_MATCH_QUERY = '@timestamp >= "now-30d"';
 
+export enum CloudPosturePage {
+  rules = 'csp_rules',
+  alerts = 'csp_alerts',
+  findings = 'csp_findings',
+  dashboard = 'csp_dashboard',
+}
+
 export enum SecurityPageName {
   administration = 'administration',
   alerts = 'alerts',
@@ -103,6 +110,7 @@ export enum SecurityPageName {
   trustedApps = 'trusted_apps',
   ueba = 'ueba',
   uncommonProcesses = 'uncommon_processes',
+  cloud_posture = 'cloud_posture',
 }
 
 export const TIMELINES_PATH = '/timelines';

--- a/x-pack/plugins/security_solution/public/app/deep_links/index.ts
+++ b/x-pack/plugins/security_solution/public/app/deep_links/index.ts
@@ -9,7 +9,7 @@ import { i18n } from '@kbn/i18n';
 
 import { isEmpty } from 'lodash';
 import { LicenseType } from '../../../../licensing/common/types';
-import { SecurityPageName } from '../types';
+import { SecurityPageName, CloudPosturePage } from '../types';
 import { AppDeepLink, ApplicationStart, AppNavLinkStatus } from '../../../../../../src/core/public';
 import {
   OVERVIEW,
@@ -333,6 +333,39 @@ export const securitySolutionsDeepLinks: AppDeepLink[] = [
         id: SecurityPageName.hostIsolationExceptions,
         title: HOST_ISOLATION_EXCEPTIONS,
         path: HOST_ISOLATION_EXCEPTIONS_PATH,
+      },
+    ],
+  },
+  {
+    id: SecurityPageName.cloud_posture,
+    title: 'Cloud Posture',
+    path: '/csp',
+    navLinkStatus: AppNavLinkStatus.visible,
+    keywords: [],
+    deepLinks: [
+      {
+        id: CloudPosturePage.dashboard,
+        title: 'Dashboard',
+        // eslint-disable-next-line prettier/prettier
+        path: '/csp/dashboard',
+      },
+      {
+        id: CloudPosturePage.rules,
+        title: 'Rules',
+        // eslint-disable-next-line prettier/prettier
+        path: '/csp/rules',
+      },
+      {
+        id: CloudPosturePage.alerts,
+        title: 'Alerts',
+        // eslint-disable-next-line prettier/prettier
+        path: '/csp/alerts',
+      },
+      {
+        id: CloudPosturePage.findings,
+        title: 'Findings',
+        // eslint-disable-next-line prettier/prettier
+        path: '/csp/findings',
       },
     ],
   },

--- a/x-pack/plugins/security_solution/public/app/home/home_navigations.ts
+++ b/x-pack/plugins/security_solution/public/app/home/home_navigations.ts
@@ -10,6 +10,7 @@ import {
   SecurityNav,
   SecurityNavGroup,
   SecurityNavGroupKey,
+  NavTab,
 } from '../../common/components/navigation/types';
 import {
   APP_OVERVIEW_PATH,
@@ -26,8 +27,40 @@ import {
   APP_EVENT_FILTERS_PATH,
   APP_UEBA_PATH,
   SecurityPageName,
+  CloudPosturePage,
   APP_HOST_ISOLATION_EXCEPTIONS_PATH,
 } from '../../../common/constants';
+
+export const cloudPostureNavTabs: Record<CloudPosturePage, NavTab> = {
+  [CloudPosturePage.dashboard]: {
+    id: CloudPosturePage.dashboard,
+    name: 'Dashboard',
+    href: '/csp/dashboard',
+    disabled: false,
+    // urlKey: 'administration',
+  },
+  [CloudPosturePage.rules]: {
+    id: CloudPosturePage.rules,
+    name: 'Rules',
+    href: '/csp/rules',
+    disabled: false,
+    // urlKey: 'administration',
+  },
+  [CloudPosturePage.alerts]: {
+    id: CloudPosturePage.alerts,
+    name: 'Alerts',
+    href: '/csp/alerts',
+    disabled: false,
+    // urlKey: 'administration',
+  },
+  [CloudPosturePage.findings]: {
+    id: CloudPosturePage.findings,
+    name: 'Findings',
+    href: '/csp/findings',
+    disabled: false,
+    // urlKey: 'administration',
+  },
+};
 
 export const navTabs: SecurityNav = {
   [SecurityPageName.overview]: {

--- a/x-pack/plugins/security_solution/public/app/home/template_wrapper/index.tsx
+++ b/x-pack/plugins/security_solution/public/app/home/template_wrapper/index.tsx
@@ -7,6 +7,8 @@
 
 import React, { useMemo } from 'react';
 import styled from 'styled-components';
+import { useLocation } from 'react-router-dom';
+
 import { EuiPanel } from '@elastic/eui';
 import { IS_DRAGGING_CLASS_NAME } from '@kbn/securitysolution-t-grid';
 import { AppLeaveHandler } from '../../../../../../../src/core/public';
@@ -27,7 +29,8 @@ import {
 import { useShowTimeline } from '../../../common/utils/timeline/use_show_timeline';
 import { gutterTimeline } from '../../../common/lib/helpers';
 import { useShowPagesWithEmptyView } from '../../../common/utils/empty_view/use_show_pages_with_empty_view';
-
+import { navTabs, cloudPostureNavTabs } from '../home_navigations';
+import { useRouteSpy } from '../../../common/utils/route/use_route_spy';
 /**
  * Need to apply the styles via a className to effect the containing bottom bar
  * rather than applying them to the timeline bar directly
@@ -67,9 +70,15 @@ interface SecuritySolutionPageWrapperProps {
   onAppLeave: (handler: AppLeaveHandler) => void;
 }
 
+const isCloudPostureNav = (v: string) => v?.includes('/csp');
+
 export const SecuritySolutionTemplateWrapper: React.FC<SecuritySolutionPageWrapperProps> =
   React.memo(({ children, onAppLeave }) => {
-    const solutionNav = useSecuritySolutionNavigation();
+    const loc = useLocation();
+    // Temp hack
+    const solutionNav = useSecuritySolutionNavigation(
+      isCloudPostureNav(loc.pathname) ? { ...cloudPostureNavTabs, ueba: {} } : navTabs
+    );
     const [isTimelineBottomBarVisible] = useShowTimeline();
     const getTimelineShowStatus = useMemo(() => getTimelineShowStatusByIdSelector(), []);
     const { show: isShowingTimelineOverlay } = useDeepEqualSelector((state) =>

--- a/x-pack/plugins/security_solution/public/app/index.tsx
+++ b/x-pack/plugins/security_solution/public/app/index.tsx
@@ -7,7 +7,8 @@
 
 import React from 'react';
 import { render, unmountComponentAtNode } from 'react-dom';
-import { Route, Switch } from 'react-router-dom';
+import { Redirect, RouteProps, Route, Switch } from 'react-router-dom';
+import { OVERVIEW_PATH } from '../../common/constants';
 
 import { NotFoundPage } from './404';
 import { SecurityApp } from './app';
@@ -25,6 +26,7 @@ export const renderApp = ({
 }: RenderAppProps): (() => void) => {
   const ApplicationUsageTrackingProvider =
     usageCollection?.components.ApplicationUsageTrackingProvider ?? React.Fragment;
+
   render(
     <SecurityApp
       history={history}
@@ -35,9 +37,32 @@ export const renderApp = ({
     >
       <ApplicationUsageTrackingProvider>
         <Switch>
+<<<<<<< HEAD
           {subPluginRoutes.map((route, index) => {
             return <Route key={`route-${index}`} {...route} />;
           })}
+=======
+          {[
+            ...subPlugins.overview.routes,
+            ...subPlugins.alerts.routes,
+            ...subPlugins.rules.routes,
+            ...subPlugins.exceptions.routes,
+            ...subPlugins.hosts.routes,
+            ...subPlugins.network.routes,
+            // will be undefined if enabledExperimental.uebaEnabled === false
+            ...(subPlugins.ueba != null ? subPlugins.ueba.routes : []),
+            ...subPlugins.timelines.routes,
+            ...subPlugins.cases.routes,
+            ...subPlugins.management.routes,
+            ...subPlugins.cloud_posture.routes,
+          ].map((route, index) => (
+            <Route key={`route-${index}`} {...route} />
+          ))}
+
+          <Route path="" exact>
+            <Redirect to={OVERVIEW_PATH} />
+          </Route>
+>>>>>>> initial entry point
           <Route>
             <NotFoundPage />
           </Route>

--- a/x-pack/plugins/security_solution/public/app/types.ts
+++ b/x-pack/plugins/security_solution/public/app/types.ts
@@ -35,7 +35,7 @@ import { Immutable } from '../../common/endpoint/types';
 import { AppAction } from '../common/store/actions';
 import { TimelineState } from '../timelines/store/timeline/types';
 
-export { SecurityPageName } from '../../common/constants';
+export { SecurityPageName, CloudPosturePage } from '../../common/constants';
 
 export interface SecuritySubPluginStore<K extends SecuritySubPluginKeyStore, T> {
   initialState: Record<K, T>;

--- a/x-pack/plugins/security_solution/public/cloud_posture/index.ts
+++ b/x-pack/plugins/security_solution/public/cloud_posture/index.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { Storage } from '../../../../../src/plugins/kibana_utils/public';
+import { CoreStart } from '../../../../../src/core/public';
+import { routes } from './routes';
+import { StartPlugins } from '../types';
+import { SecuritySubPlugin } from '../app/types';
+
+export class CloudPosture {
+  public setup() {}
+  public start(storage: Storage, core: CoreStart, plugins: StartPlugins): SecuritySubPlugin {
+    return {
+      storageTimelines: {
+        timelineById: {},
+      },
+      routes,
+    };
+  }
+}

--- a/x-pack/plugins/security_solution/public/cloud_posture/pages/alerts/index.tsx
+++ b/x-pack/plugins/security_solution/public/cloud_posture/pages/alerts/index.tsx
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiSpacer } from '@elastic/eui';
+import { SecuritySolutionPageWrapper } from '../../../common/components/page_wrapper';
+import { HeaderPage } from '../../../common/components/header_page';
+
+export const Alerts = () => {
+  return (
+    <SecuritySolutionPageWrapper noPadding={false} data-test-subj="csp_alerts">
+      <HeaderPage hideSourcerer border title={'Alerts'} />
+      <EuiSpacer />
+    </SecuritySolutionPageWrapper>
+  );
+};

--- a/x-pack/plugins/security_solution/public/cloud_posture/pages/dashboard/index.tsx
+++ b/x-pack/plugins/security_solution/public/cloud_posture/pages/dashboard/index.tsx
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiSpacer } from '@elastic/eui';
+import { SecuritySolutionPageWrapper } from '../../../common/components/page_wrapper';
+import { HeaderPage } from '../../../common/components/header_page';
+
+export const Dashboard = () => {
+  return (
+    <SecuritySolutionPageWrapper noPadding={false} data-test-subj="csp_rules">
+      <HeaderPage hideSourcerer border title={'Dashboard'} />
+      <EuiSpacer />
+    </SecuritySolutionPageWrapper>
+  );
+};

--- a/x-pack/plugins/security_solution/public/cloud_posture/pages/findings/index.tsx
+++ b/x-pack/plugins/security_solution/public/cloud_posture/pages/findings/index.tsx
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiSpacer } from '@elastic/eui';
+import { SecuritySolutionPageWrapper } from '../../../common/components/page_wrapper';
+import { HeaderPage } from '../../../common/components/header_page';
+
+export const Findings = () => {
+  return (
+    <SecuritySolutionPageWrapper noPadding={false} data-test-subj="csp_rules">
+      <HeaderPage hideSourcerer border title={'Findings'} />
+      <EuiSpacer />
+    </SecuritySolutionPageWrapper>
+  );
+};

--- a/x-pack/plugins/security_solution/public/cloud_posture/pages/rules/index.tsx
+++ b/x-pack/plugins/security_solution/public/cloud_posture/pages/rules/index.tsx
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiSpacer } from '@elastic/eui';
+import { SecuritySolutionPageWrapper } from '../../../common/components/page_wrapper';
+import { HeaderPage } from '../../../common/components/header_page';
+
+export const Rules = () => {
+  return (
+    <SecuritySolutionPageWrapper noPadding={false} data-test-subj="csp_rules">
+      <HeaderPage hideSourcerer border title={'Rules'} />
+      <EuiSpacer />
+    </SecuritySolutionPageWrapper>
+  );
+};

--- a/x-pack/plugins/security_solution/public/cloud_posture/routes.tsx
+++ b/x-pack/plugins/security_solution/public/cloud_posture/routes.tsx
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React from 'react';
+import { Redirect, RouteProps, RouteComponentProps, Switch, Route } from 'react-router-dom';
+
+import { Dashboard } from './pages/dashboard';
+import { Alerts } from './pages/alerts';
+import { Rules } from './pages/rules';
+import { Findings } from './pages/findings';
+import { SpyRoute } from '../common/utils/route/spy_routes';
+import { SecurityPageName } from '../app/types';
+
+const innerRoutes: RouteProps[] = [
+  { path: '/csp/dashboard', render: Dashboard },
+  { path: '/csp/rules', render: Rules },
+  { path: '/csp/alerts', render: Alerts },
+  { path: '/csp/findings', render: Findings },
+];
+
+const pages = innerRoutes.map((v) => <Route key={v.path as string} {...v} />);
+
+const Routes = (props: RouteComponentProps<{}>) => (
+  <>
+    <Switch>
+      <Route path="/csp" exact render={() => <Redirect to="/csp/dashboard" />} />
+      {pages}
+      <Route path="*">{`Not Found`}</Route>
+    </Switch>
+    <SpyRoute pageName={SecurityPageName.cloud_posture} />
+  </>
+);
+
+export const routes: RouteProps[] = [{ path: '/csp', render: Routes }];

--- a/x-pack/plugins/security_solution/public/common/components/navigation/use_security_solution_navigation/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/navigation/use_security_solution_navigation/index.tsx
@@ -11,7 +11,7 @@ import { useKibana } from '../../../lib/kibana';
 import { useSetBreadcrumbs } from '../breadcrumbs';
 import { makeMapStateToProps } from '../../url_state/helpers';
 import { useRouteSpy } from '../../../utils/route/use_route_spy';
-import { navTabs } from '../../../../app/home/home_navigations';
+// import { navTabs } from '../../../../app/home/home_navigations';
 import { useDeepEqualSelector } from '../../../hooks/use_selector';
 import { useIsExperimentalFeatureEnabled } from '../../../hooks/use_experimental_features';
 import { GenericNavRecord } from '../types';
@@ -20,7 +20,7 @@ import { GenericNavRecord } from '../types';
  * @description - This hook provides the structure necessary by the KibanaPageTemplate for rendering the primary security_solution side navigation.
  * TODO: Consolidate & re-use the logic in the hooks in this directory that are replicated from the tab_navigation to maintain breadcrumbs, telemetry, etc...
  */
-export const useSecuritySolutionNavigation = () => {
+export const useSecuritySolutionNavigation = (navTabs: any) => {
   const [routeProps] = useRouteSpy();
   const urlMapState = makeMapStateToProps();
   const { urlState } = useDeepEqualSelector(urlMapState);

--- a/x-pack/plugins/security_solution/public/common/components/navigation/use_security_solution_navigation/use_navigation_items.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/navigation/use_security_solution_navigation/use_navigation_items.tsx
@@ -8,6 +8,8 @@
 import React, { useCallback, useMemo } from 'react';
 import { EuiSideNavItemType } from '@elastic/eui/src/components/side_nav/side_nav_types';
 
+import { useLocation } from 'react-router-dom';
+
 import { securityNavGroup } from '../../../../app/home/home_navigations';
 import { getSearch } from '../helpers';
 import { PrimaryNavigationItemsProps } from './types';
@@ -35,7 +37,6 @@ export const usePrimaryNavigationItems = ({
       };
 
       const appHref = getAppUrl({ deepLinkId: id, path: urlSearch });
-
       return {
         'data-href': appHref,
         'data-test-subj': `navigation-${id}`,
@@ -62,13 +63,26 @@ export const usePrimaryNavigationItems = ({
   );
 };
 
+const useIsCloudPosture = () => !!useLocation()?.pathname?.includes('/csp');
+
 function usePrimaryNavigationItemsToDisplay(navTabs: Record<string, NavTab>) {
   const hasCasesReadPermissions = useGetUserCasesPermissions()?.read;
   const canSeeHostIsolationExceptions = useCanSeeHostIsolationExceptionsMenu();
   const uiCapabilities = useKibana().services.application.capabilities;
+
+  const isCSP = useIsCloudPosture(); // Temp Hack
+
   return useMemo(
     () =>
-      uiCapabilities.siem.show
+      isCSP
+        ? [
+            {
+              id: 'cloud_posture',
+              name: 'Cloud  Posture',
+              items: Object.values(navTabs),
+            },
+          ]
+        : uiCapabilities.siem.show
         ? [
             {
               id: 'main',

--- a/x-pack/plugins/security_solution/public/common/components/url_state/constants.ts
+++ b/x-pack/plugins/security_solution/public/common/components/url_state/constants.ts
@@ -35,4 +35,5 @@ export type UrlStateType =
   | 'overview'
   | 'rules'
   | 'timeline'
-  | 'ueba';
+  | 'ueba'
+  | 'cloud_posture';

--- a/x-pack/plugins/security_solution/public/common/components/url_state/helpers.ts
+++ b/x-pack/plugins/security_solution/public/common/components/url_state/helpers.ts
@@ -109,6 +109,8 @@ export const getUrlType = (pageName: string): UrlStateType => {
     return 'case';
   } else if (pageName === SecurityPageName.administration) {
     return 'administration';
+  } else if (pageName === SecurityPageName.cloud_posture) {
+    return 'cloud_posture';
   }
   return 'overview';
 };

--- a/x-pack/plugins/security_solution/public/lazy_sub_plugins.tsx
+++ b/x-pack/plugins/security_solution/public/lazy_sub_plugins.tsx
@@ -24,6 +24,11 @@ import { Timelines } from './timelines';
 import { Management } from './management';
 
 /**
+ * Temporary initial cloud posture FE
+ */
+import { CloudPosture } from './cloud_posture';
+
+/**
  * The classes used to instantiate the sub plugins. These are grouped into a single object for the sake of bundling them in a single dynamic import.
  */
 const subPluginClasses = {
@@ -37,5 +42,6 @@ const subPluginClasses = {
   Rules,
   Timelines,
   Management,
+  CloudPosture,
 };
 export { subPluginClasses };

--- a/x-pack/plugins/security_solution/public/plugin.tsx
+++ b/x-pack/plugins/security_solution/public/plugin.tsx
@@ -301,6 +301,7 @@ export class Plugin implements IPlugin<PluginSetup, PluginStart, SetupPlugins, S
         overview: new subPluginClasses.Overview(),
         timelines: new subPluginClasses.Timelines(),
         management: new subPluginClasses.Management(),
+        cloud_posture: new subPluginClasses.CloudPosture(),
       };
     }
     return this._subPlugins;
@@ -326,6 +327,7 @@ export class Plugin implements IPlugin<PluginSetup, PluginStart, SetupPlugins, S
       ueba: subPlugins.ueba.start(storage),
       timelines: subPlugins.timelines.start(),
       management: subPlugins.management.start(core, plugins),
+      cloud_posture: subPlugins.cloud_posture.start(storage, core, plugins),
     };
   }
 

--- a/x-pack/plugins/security_solution/public/types.ts
+++ b/x-pack/plugins/security_solution/public/types.ts
@@ -39,6 +39,7 @@ import { Rules } from './rules';
 import { Timelines } from './timelines';
 import { Management } from './management';
 import { Ueba } from './ueba';
+import { CloudPosture } from './cloud_posture';
 import { LicensingPluginStart, LicensingPluginSetup } from '../../licensing/public';
 import { DashboardStart } from '../../../../src/plugins/dashboard/public';
 
@@ -99,6 +100,7 @@ export interface SubPlugins {
   overview: Overview;
   timelines: Timelines;
   management: Management;
+  cloud_posture: CloudPosture;
 }
 
 // TODO: find a better way to defined these types
@@ -113,4 +115,5 @@ export interface StartedSubPlugins {
   overview: ReturnType<Overview['start']>;
   timelines: ReturnType<Timelines['start']>;
   management: ReturnType<Management['start']>;
+  cloud_posture: ReturnType<CloudPosture['start']>;
 }


### PR DESCRIPTION
this PR is meant to address 2 issues: 
- https://github.com/elastic/security-team/issues/1933
- https://github.com/elastic/security-team/issues/1945

one way to address this issue is already explored in https://github.com/build-security/kibana/pull/1
in this PR the approach taken is different (both in inner routing and sidebar navigation)
and adds a cloud posture navigation sidebar which can be accessed from the root security solution navigation.

https://user-images.githubusercontent.com/20814186/138895807-31185ea2-4e9d-4c33-903a-738a4e54134b.mov


