### PR TITLE
Flyout refactor

### DIFF
--- a/x-pack/plugins/security_solution/public/cloud_posture/pages/findings/rule_flyout.tsx
+++ b/x-pack/plugins/security_solution/public/cloud_posture/pages/findings/rule_flyout.tsx
@@ -30,10 +30,7 @@ const tabs = ['result', 'rule', 'resource'] as const;
 
 type FindingsTab = typeof tabs[number];
 
-type EuiListItemsProps = Extract<
-  PropsOf<typeof EuiDescriptionList>['listItems'],
-  unknown[]
->[number];
+type EuiListItemsProps = NonNullable<PropsOf<typeof EuiDescriptionList>['listItems']>[number];
 
 interface Card {
   title: string;

--- a/x-pack/plugins/security_solution/public/cloud_posture/pages/findings/rule_flyout.tsx
+++ b/x-pack/plugins/security_solution/public/cloud_posture/pages/findings/rule_flyout.tsx
@@ -26,7 +26,7 @@ import { assertNever } from '@kbn/std';
 import { CSPFinding } from './types';
 import { CSPEvaluationBadge } from '../../components/csp_evaluation_badge';
 
-const tabs = ['resource', 'rule', 'result', 'run'] as const;
+const tabs = ['result', 'rule', 'resource'] as const;
 
 type FindingsTab = typeof tabs[number];
 
@@ -47,7 +47,7 @@ interface FindingFlyoutProps {
 
 // TODO: fix scrollbar jumps
 export const FindingsRuleFlyout = ({ onClose, findings }: FindingFlyoutProps) => {
-  const [tab, setTab] = useState<FindingsTab>('resource');
+  const [tab, setTab] = useState<FindingsTab>('result');
   return (
     <EuiFlyout onClose={onClose}>
       <EuiFlyoutHeader>
@@ -95,8 +95,6 @@ const Cards = ({ data }: { data: Card[] }) => (
 
 const FindingsTab = ({ tab, findings }: { findings: CSPFinding; tab: FindingsTab }) => {
   switch (tab) {
-    case 'run':
-      return <Cards data={getRunCards(findings)} />;
     case 'result':
       return <Cards data={getResultCards(findings)} />;
     case 'rule':
@@ -141,17 +139,16 @@ const getRuleCards = ({ rule }: CSPFinding): Card[] => [
   },
 ];
 
-const getResultCards = ({ result }: CSPFinding): Card[] => [
+const getResultCards = ({ result, agent, host, ...rest }: CSPFinding): Card[] => [
   {
     title: 'Result',
     listItems: [
       ['Evaluation', <CSPEvaluationBadge type={result.evaluation} />],
       ['Evidence', <EuiCode>{JSON.stringify(result.evidence, null, 2)}</EuiCode>],
-    ],
+      ['Timestamp', rest['@timestamp']],
+      result.evaluation === 'failed' && ['Remediation', rest['@timestamp']],
+    ].filter(Boolean) as Card['listItems'], // TODO: is a type guard,
   },
-];
-
-const getRunCards = ({ agent, host }: CSPFinding): Card[] => [
   {
     title: 'Agent',
     listItems: [

--- a/x-pack/plugins/security_solution/public/cloud_posture/pages/findings/rule_flyout.tsx
+++ b/x-pack/plugins/security_solution/public/cloud_posture/pages/findings/rule_flyout.tsx
@@ -146,7 +146,7 @@ const getResultCards = ({ result, agent, host, ...rest }: CSPFinding): Card[] =>
       ['Evaluation', <CSPEvaluationBadge type={result.evaluation} />],
       ['Evidence', <EuiCode>{JSON.stringify(result.evidence, null, 2)}</EuiCode>],
       ['Timestamp', rest['@timestamp']],
-      result.evaluation === 'failed' && ['Remediation', rest['@timestamp']],
+      result.evaluation === 'failed' && ['Remediation', rest.rule.remediation],
     ].filter(Boolean) as Card['listItems'], // TODO: is a type guard,
   },
   {

--- a/x-pack/plugins/security_solution/public/cloud_posture/pages/findings/rule_flyout.tsx
+++ b/x-pack/plugins/security_solution/public/cloud_posture/pages/findings/rule_flyout.tsx
@@ -4,9 +4,9 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-
-import React, { ReactNode, useState, useCallback } from 'react';
+import React, { useState } from 'react';
 import {
+  EuiFlexItem,
   EuiSpacer,
   EuiCode,
   EuiDescriptionList,
@@ -18,20 +18,26 @@ import {
   EuiBadge,
   EuiTabs,
   EuiTab,
+  EuiFlexGrid,
   EuiCard,
+  PropsOf,
 } from '@elastic/eui';
 import { assertNever } from '@kbn/std';
 import { CSPFinding } from './types';
 import { CSPEvaluationBadge } from '../../components/csp_evaluation_badge';
 
-const tabs = ['resource', 'rule', 'overview'] as const;
+const tabs = ['resource', 'rule', 'result', 'run'] as const;
+
+type FindingsTab = typeof tabs[number];
+
+type EuiListItemsProps = Extract<
+  PropsOf<typeof EuiDescriptionList>['listItems'],
+  unknown[]
+>[number];
 
 interface Card {
   title: string;
-  listItems: Array<{
-    title: NonNullable<ReactNode>;
-    description: NonNullable<ReactNode>;
-  }>;
+  listItems: Array<[EuiListItemsProps['title'], EuiListItemsProps['description']]>;
 }
 
 interface FindingFlyoutProps {
@@ -39,25 +45,12 @@ interface FindingFlyoutProps {
   findings: CSPFinding;
 }
 
+// TODO: fix scrollbar jumps
 export const FindingsRuleFlyout = ({ onClose, findings }: FindingFlyoutProps) => {
-  const [tab, setTab] = useState<typeof tabs[number]>('resource');
-
-  const Tab = useCallback(() => {
-    switch (tab) {
-      case 'overview':
-        return <FlyoutTab cards={getOverviewCards(findings)} />;
-      case 'rule':
-        return <FlyoutTab cards={getRuleCards(findings)} />;
-      case 'resource':
-        return <FlyoutTab cards={getResourceCards(findings)} />;
-    }
-
-    assertNever(tab);
-  }, [findings, tab]);
-
+  const [tab, setTab] = useState<FindingsTab>('resource');
   return (
     <EuiFlyout onClose={onClose}>
-      <EuiFlyoutHeader aria-labelledby={'foo'}>
+      <EuiFlyoutHeader>
         <EuiTitle size="l">
           <EuiTextColor color="primary">
             <h2>{'Findings'}</h2>
@@ -78,57 +71,52 @@ export const FindingsRuleFlyout = ({ onClose, findings }: FindingFlyoutProps) =>
         </EuiTabs>
       </EuiFlyoutHeader>
       <EuiFlyoutBody>
-        <Tab />
+        <FindingsTab tab={tab} findings={findings} />
       </EuiFlyoutBody>
     </EuiFlyout>
   );
 };
 
-const FlyoutTab = ({ cards }: { cards: Card[] }) => (
-  <div style={{ display: 'grid', gridGap: 15, gridAutoFlow: 'rows' }}>
-    {cards.map((card) => (
-      <EuiCard textAlign="left" title={card.title}>
-        <EuiDescriptionList compressed={false} type="column" listItems={card.listItems} />
-      </EuiCard>
+const Cards = ({ data }: { data: Card[] }) => (
+  <EuiFlexGrid direction="column" gutterSize={'l'}>
+    {data.map((card) => (
+      <EuiFlexItem key={card.title} style={{ display: 'block' }}>
+        <EuiCard textAlign="left" title={card.title}>
+          <EuiDescriptionList
+            compressed={false}
+            type="column"
+            listItems={card.listItems.map((v) => ({ title: v[0], description: v[1] }))}
+          />
+        </EuiCard>
+      </EuiFlexItem>
     ))}
-  </div>
+  </EuiFlexGrid>
 );
 
-const getOverviewCards = ({ agent, host }: CSPFinding): Card[] => [
+const FindingsTab = ({ tab, findings }: { findings: CSPFinding; tab: FindingsTab }) => {
+  switch (tab) {
+    case 'run':
+      return <Cards data={getRunCards(findings)} />;
+    case 'result':
+      return <Cards data={getResultCards(findings)} />;
+    case 'rule':
+      return <Cards data={getRuleCards(findings)} />;
+    case 'resource':
+      return <Cards data={getResourceCards(findings)} />;
+  }
+  assertNever(tab);
+};
+
+const getResourceCards = ({ resource, result }: CSPFinding): Card[] => [
   {
-    title: 'Agent',
+    title: 'Resource',
     listItems: [
-      { title: 'Name', description: agent.name },
-      { title: 'ID', description: agent.id },
-      { title: 'Type', description: agent.type },
-      { title: 'Version', description: agent.version },
-    ],
-  },
-  {
-    title: 'Host',
-    listItems: [
-      { title: 'Architecture', description: host.architecture },
-      {
-        title: 'Containerized',
-        description: host.containerized ? 'true' : 'false',
-      },
-      { title: 'Hostname', description: host.hostname },
-      { title: 'ID', description: host.id },
-      { title: 'IP', description: host.ip.join(',') },
-      { title: 'Mac', description: host.mac.join(',') },
-      { title: 'Name', description: host.name },
-    ],
-  },
-  {
-    title: 'OS',
-    listItems: [
-      { title: 'Codename', description: host.os.codename },
-      { title: 'Family', description: host.os.family },
-      { title: 'Kernel', description: host.os.kernel },
-      { title: 'Name', description: host.os.name },
-      { title: 'Platform', description: host.os.platform },
-      { title: 'Type', description: host.os.type },
-      { title: 'Version', description: host.os.version },
+      ['Filename', <EuiCode>{resource.filename}</EuiCode>],
+      ['Mode', resource.mode],
+      ['Path', <EuiCode>{resource.path}</EuiCode>],
+      ['Type', resource.type],
+      ['UID', resource.uid],
+      ['GID', resource.gid],
     ],
   },
 ];
@@ -137,45 +125,64 @@ const getRuleCards = ({ rule }: CSPFinding): Card[] => [
   {
     title: 'Rule',
     listItems: [
-      { title: 'Benchmark', description: rule.benchmark },
-      { title: 'Name', description: rule.name },
-      { title: 'Description', description: rule.description },
-      {
-        title: 'Tags',
-        description: rule.tags.map((t) => (
+      ['Benchmark', rule.benchmark],
+      ['Name', rule.name],
+      ['Description', rule.description],
+      ['Remediation', <EuiCode>{rule.remediation}</EuiCode>],
+      [
+        'Tags',
+        rule.tags.map((t) => (
           <EuiBadge key={t} color="default">
             {t}
           </EuiBadge>
         )),
-      },
-      { title: 'Remediation', description: <EuiCode>{rule.remediation}</EuiCode> },
+      ],
     ],
   },
 ];
 
-const getResourceCards = ({ resource, result }: CSPFinding): Card[] => [
-  {
-    title: 'Resource',
-    listItems: [
-      { title: 'Filename', description: <EuiCode>{resource.filename}</EuiCode> },
-      { title: 'Mode', description: resource.mode },
-      { title: 'Path', description: <EuiCode>{resource.path}</EuiCode> },
-      { title: 'Type', description: resource.type },
-      { title: 'UID', description: resource.uid },
-      { title: 'GID', description: resource.gid },
-    ],
-  },
+const getResultCards = ({ result }: CSPFinding): Card[] => [
   {
     title: 'Result',
     listItems: [
-      {
-        title: 'Evaluation',
-        description: <CSPEvaluationBadge type={result.evaluation} />,
-      },
-      {
-        title: 'Evidence',
-        description: <EuiCode>{JSON.stringify(result.evidence, null, 2)}</EuiCode>,
-      },
+      ['Evaluation', <CSPEvaluationBadge type={result.evaluation} />],
+      ['Evidence', <EuiCode>{JSON.stringify(result.evidence, null, 2)}</EuiCode>],
+    ],
+  },
+];
+
+const getRunCards = ({ agent, host }: CSPFinding): Card[] => [
+  {
+    title: 'Agent',
+    listItems: [
+      ['Name', agent.name],
+      ['ID', agent.id],
+      ['Type', agent.type],
+      ['Version', agent.version],
+    ],
+  },
+  {
+    title: 'Host',
+    listItems: [
+      ['Architecture', host.architecture],
+      ['Containerized', host.containerized ? 'true' : 'false'],
+      ['Hostname', host.hostname],
+      ['ID', host.id],
+      ['IP', host.ip.join(',')],
+      ['Mac', host.mac.join(',')],
+      ['Name', host.name],
+    ],
+  },
+  {
+    title: 'OS',
+    listItems: [
+      ['Codename', host.os.codename],
+      ['Family', host.os.family],
+      ['Kernel', host.os.kernel],
+      ['Name', host.os.name],
+      ['Platform', host.os.platform],
+      ['Type', host.os.type],
+      ['Version', host.os.version],
     ],
   },
 ];


### PR DESCRIPTION
this PR cleans up the code for the flytout, while making improvements based on discussion at 
- https://github.com/elastic/security-team/issues/2362

notably - 

- [x] changed tabs to be `Result, Rule, Resource`
- [x] added `@timestamp` and `Remediation` to `Result` tab

TODO:

- [ ] add cluster info
- [ ] add OPA info


----

### screenshot



<img width="868" alt="Screen Shot 2021-12-05 at 14 37 30" src="https://user-images.githubusercontent.com/20814186/144746842-d1aacd89-2e60-49ce-861e-acda307e857d.png">

