### PR TITLE
CSP Root plugin

### DIFF
--- a/x-pack/plugins/cloud_security_posture/kibana.json
+++ b/x-pack/plugins/cloud_security_posture/kibana.json
@@ -1,0 +1,14 @@
+{
+  "id": "csp",
+  "owner": {
+    "name": "Cloud Security Posture",
+    "githubTeam": "csp"
+  },
+  "version": "8.0.0",
+  "kibanaVersion": "kibana",
+  "server": true,
+  "ui": true,
+  "configPath": ["xpack", "csp"],
+  "requiredPlugins": [],
+  "requiredBundles": []
+}

--- a/x-pack/plugins/cloud_security_posture/public/app.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/app.tsx
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { AppMountParameters } from 'kibana/public';
+import { Redirect, Router, Route } from 'react-router-dom';
+
+type Props = any;
+
+const Dashboard = () => <div>CSP Dashboard</div>;
+
+const App = ({ history }: Props) => (
+  <Router history={history}>
+    <Route path="/dashboard" component={Dashboard} />
+    <Route exact path="" component={() => <Redirect to={'/dashboard'} />} />
+  </Router>
+);
+
+export const renderApp = (props: AppMountParameters) => {
+  ReactDOM.render(<App {...props} />, props.element);
+
+  return () => ReactDOM.unmountComponentAtNode(props.element);
+};

--- a/x-pack/plugins/cloud_security_posture/public/index.ts
+++ b/x-pack/plugins/cloud_security_posture/public/index.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { PluginInitializer } from 'kibana/public';
+import { RoutingExamplePlugin } from './plugin';
+
+export const plugin: PluginInitializer<{}, {}> = () => new RoutingExamplePlugin();

--- a/x-pack/plugins/cloud_security_posture/public/index.ts
+++ b/x-pack/plugins/cloud_security_posture/public/index.ts
@@ -7,6 +7,6 @@
  */
 
 import { PluginInitializer } from 'kibana/public';
-import { RoutingExamplePlugin } from './plugin';
+import { CSPPlugin } from './plugin';
 
-export const plugin: PluginInitializer<{}, {}> = () => new RoutingExamplePlugin();
+export const plugin: PluginInitializer<{}, {}> = () => new CSPPlugin();

--- a/x-pack/plugins/cloud_security_posture/public/plugin.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/plugin.tsx
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import {
+  CoreStart,
+  Plugin,
+  CoreSetup,
+  AppMountParameters,
+  AppNavLinkStatus,
+} from '../../../../src/core/public';
+
+interface SetupDeps {}
+
+export class CSPPlugin implements Plugin<{}, {}, SetupDeps, {}> {
+  public setup(core: CoreSetup, {}: SetupDeps) {
+    core.application.register({
+      id: 'csp_root',
+      title: 'CSP root',
+      navLinkStatus: AppNavLinkStatus.visible,
+      async mount(params: AppMountParameters) {
+        const [coreStart] = await core.getStartServices();
+        const { renderApp } = await import('./app');
+        return renderApp(params);
+      },
+    });
+
+    return {};
+  }
+
+  public start(core: CoreStart) {
+    return {};
+  }
+
+  public stop() {}
+}

--- a/x-pack/plugins/cloud_security_posture/server/index.ts
+++ b/x-pack/plugins/cloud_security_posture/server/index.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { PluginInitializer } from 'kibana/server';
+
+import { CSPPlugin } from './plugin';
+
+export const plugin: PluginInitializer<{}, {}> = () => new CSPPlugin();

--- a/x-pack/plugins/cloud_security_posture/server/plugin.ts
+++ b/x-pack/plugins/cloud_security_posture/server/plugin.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { Plugin, CoreSetup, CoreStart } from 'kibana/server';
+import { registerRoutes } from './routes';
+
+export class CSPPlugin implements Plugin<{}, {}> {
+  public setup(core: CoreSetup) {
+    const router = core.http.createRouter();
+
+    registerRoutes(router);
+
+    return {};
+  }
+
+  public start(core: CoreStart) {
+    return {};
+  }
+
+  public stop() {}
+}

--- a/x-pack/plugins/cloud_security_posture/server/routes/index.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/index.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+export { registerRoutes } from './register_routes';

--- a/x-pack/plugins/cloud_security_posture/server/routes/random_number_generator.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/random_number_generator.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { IRouter } from '../../../../../src/core/server';
+
+export function registerGetRandomNumberRoute(router: IRouter) {
+  router.get(
+    {
+      path: '/foo',
+      validate: {},
+    },
+    async (context, request, response) => {
+      return response.ok({
+        body: {
+          randomNumber: Math.random() * 10,
+        },
+      });
+    }
+  );
+}

--- a/x-pack/plugins/cloud_security_posture/server/routes/register_routes.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/register_routes.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { IRouter } from 'kibana/server';
+import { registerGetRandomNumberRoute } from './random_number_generator';
+
+export function registerRoutes(router: IRouter) {
+  registerGetRandomNumberRoute(router);
+}

--- a/x-pack/plugins/cloud_security_posture/tsconfig.json
+++ b/x-pack/plugins/cloud_security_posture/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./target/types",
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "declarationMap": true
+  },
+  "include": ["public/**/*", "server/**/*"],
+  "references": [
+    { "path": "../../../src/core/tsconfig.json" },
+    { "path": "../../../src/plugins/data/tsconfig.json" }
+  ]
+}

--- a/x-pack/plugins/security_solution/public/app/deep_links/index.ts
+++ b/x-pack/plugins/security_solution/public/app/deep_links/index.ts
@@ -344,6 +344,13 @@ export const securitySolutionsDeepLinks: SecuritySolutionDeepLink[] = [
       },
     ],
   },
+  {
+    id: 'cloud_posture',
+    title: 'Cloud Posture',
+    path: '/csp',
+    navLinkStatus: AppNavLinkStatus.visible,
+    keywords: [],
+  },
 ];
 
 /**

--- a/x-pack/plugins/security_solution/public/cloud_posture/index.ts
+++ b/x-pack/plugins/security_solution/public/cloud_posture/index.ts
@@ -5,16 +5,12 @@
  * 2.0.
  */
 
-import { Storage } from '../../../../../src/plugins/kibana_utils/public';
-import { TimelineIdLiteral, TimelineId } from '../../common/types/timeline';
-import { SecuritySubPluginWithStore } from '../app/types';
-import { getTimelinesInStorageByIds } from '../timelines/containers/local_storage';
 import { routes } from './routes';
 
 export class CloudPosture {
   public setup() {}
 
-  public start(storage: Storage) {
+  public start() {
     return {
       routes,
       storageTimelines: {},

--- a/x-pack/plugins/security_solution/public/cloud_posture/index.ts
+++ b/x-pack/plugins/security_solution/public/cloud_posture/index.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { Storage } from '../../../../../src/plugins/kibana_utils/public';
+import { TimelineIdLiteral, TimelineId } from '../../common/types/timeline';
+import { SecuritySubPluginWithStore } from '../app/types';
+import { getTimelinesInStorageByIds } from '../timelines/containers/local_storage';
+import { routes } from './routes';
+
+export class CloudPosture {
+  public setup() {}
+
+  public start(storage: Storage) {
+    return {
+      routes,
+      storageTimelines: {},
+    };
+  }
+}

--- a/x-pack/plugins/security_solution/public/cloud_posture/routes.tsx
+++ b/x-pack/plugins/security_solution/public/cloud_posture/routes.tsx
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React from 'react';
+import { RouteProps } from 'react-router-dom';
+import { useKibana } from '../common/lib/kibana';
+
+const Routes = () => <RedirectToCSP />;
+
+export const routes: RouteProps[] = [{ path: '/csp', render: Routes }];
+
+const RedirectToCSP = () => {
+  const { navigateToApp } = useKibana().services?.application;
+  React.useEffect(() => {
+    navigateToApp('csp_root');
+  }, [navigateToApp]);
+
+  return null;
+};

--- a/x-pack/plugins/security_solution/public/lazy_sub_plugins.tsx
+++ b/x-pack/plugins/security_solution/public/lazy_sub_plugins.tsx
@@ -22,6 +22,7 @@ import { Rules } from './rules';
 
 import { Timelines } from './timelines';
 import { Management } from './management';
+import { CloudPosture } from './cloud_posture';
 
 /**
  * The classes used to instantiate the sub plugins. These are grouped into a single object for the sake of bundling them in a single dynamic import.
@@ -37,5 +38,6 @@ const subPluginClasses = {
   Rules,
   Timelines,
   Management,
+  CloudPosture,
 };
 export { subPluginClasses };

--- a/x-pack/plugins/security_solution/public/plugin.tsx
+++ b/x-pack/plugins/security_solution/public/plugin.tsx
@@ -300,6 +300,7 @@ export class Plugin implements IPlugin<PluginSetup, PluginStart, SetupPlugins, S
         overview: new subPluginClasses.Overview(),
         timelines: new subPluginClasses.Timelines(),
         management: new subPluginClasses.Management(),
+        cloudPosture: new subPluginClasses.CloudPosture(),
       };
     }
     return this._subPlugins;
@@ -325,6 +326,7 @@ export class Plugin implements IPlugin<PluginSetup, PluginStart, SetupPlugins, S
       ueba: subPlugins.ueba.start(storage),
       timelines: subPlugins.timelines.start(),
       management: subPlugins.management.start(core, plugins),
+      cloudPosture: subPlugins.cloudPosture.start(),
     };
   }
   /**

--- a/x-pack/plugins/security_solution/public/types.ts
+++ b/x-pack/plugins/security_solution/public/types.ts
@@ -38,6 +38,7 @@ import type { Overview } from './overview';
 import type { Rules } from './rules';
 import type { Timelines } from './timelines';
 import type { Management } from './management';
+import type { CloudPosture } from './cloud_posture';
 import type { Ueba } from './ueba';
 import type { LicensingPluginStart, LicensingPluginSetup } from '../../licensing/public';
 import type { DashboardStart } from '../../../../src/plugins/dashboard/public';
@@ -101,6 +102,7 @@ export interface SubPlugins {
   overview: Overview;
   timelines: Timelines;
   management: Management;
+  cloudPosture: CloudPosture;
 }
 
 // TODO: find a better way to defined these types
@@ -115,4 +117,5 @@ export interface StartedSubPlugins {
   overview: ReturnType<Overview['start']>;
   timelines: ReturnType<Timelines['start']>;
   management: ReturnType<Management['start']>;
+  cloudPosture: ReturnType<CloudPosture['start']>;
 }

--- a/x-pack/plugins/security_solution/tsconfig.json
+++ b/x-pack/plugins/security_solution/tsconfig.json
@@ -41,6 +41,7 @@
     { "path": "../ml/tsconfig.json" },
     { "path": "../spaces/tsconfig.json" },
     { "path": "../security/tsconfig.json" },
-    { "path": "../timelines/tsconfig.json" }
+    { "path": "../timelines/tsconfig.json" },
+    { "path": "../cloud_security_posture/tsconfig.json" }
   ]
 }


### PR DESCRIPTION
this branch uses a different entry point from #19 and doesn't include dashboard/findings pages
it shows how we can own a root plugin used by the security solution plugin

- [x] add `Cloud Posture` under security navigation
- [x] register sub plugin route in `security_solution` that redirect to root plugin
- [x] add `Dashboard` route in root plugin as an example route 
