### PR TITLE
csp-app-is-now-hidden

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/plugin.ts
+++ b/x-pack/plugins/cloud_security_posture/public/plugin.ts
@@ -6,7 +6,8 @@
  */
 
 import type { AppMountParameters, CoreSetup, CoreStart, Plugin } from '../../../../src/core/public';
-import type { CspSetup, CspStart, CspPluginSetup, CspPluginStart } from './types';
+import { AppNavLinkStatus, AppStatus } from '../../../../src/core/public';
+import type { CspPluginSetup, CspPluginStart, CspSetup, CspStart } from './types';
 import { PLUGIN_NAME } from '../common';
 
 export class CspPlugin implements Plugin<CspSetup, CspStart, CspPluginSetup, CspPluginStart> {
@@ -15,6 +16,8 @@ export class CspPlugin implements Plugin<CspSetup, CspStart, CspPluginSetup, Csp
     core.application.register({
       id: 'csp_root',
       title: PLUGIN_NAME,
+      status: AppStatus.accessible,
+      navLinkStatus: AppNavLinkStatus.hidden,
       async mount(params: AppMountParameters) {
         // Load application bundle
         const { renderApp } = await import('./application/index');

--- a/x-pack/plugins/security_solution/public/app/deep_links/index.ts
+++ b/x-pack/plugins/security_solution/public/app/deep_links/index.ts
@@ -11,7 +11,12 @@ import { get } from 'lodash';
 import { LicenseType } from '../../../../licensing/common/types';
 import { getCasesDeepLinks } from '../../../../cases/public';
 import { SecurityPageName, CloudPosturePage } from '../types';
-import { AppDeepLink, AppNavLinkStatus, Capabilities } from '../../../../../../src/core/public';
+import {
+  AppDeepLink,
+  AppNavLinkStatus,
+  AppStatus,
+  Capabilities,
+} from '../../../../../../src/core/public';
 import {
   OVERVIEW,
   DETECT,
@@ -351,7 +356,8 @@ export const securitySolutionsDeepLinks: SecuritySolutionDeepLink[] = [
     id: SecurityPageName.cloud_posture,
     title: 'Cloud Posture',
     path: CSP_ROOT_PATH,
-    navLinkStatus: AppNavLinkStatus.visible,
+    status: AppStatus.accessible,
+    navLinkStatus: AppNavLinkStatus.hidden,
     keywords: [],
     deepLinks: [
       {


### PR DESCRIPTION
As agreed upon in the last meeting, the CSP page is now hidden using the plugin interface of kibana. the page is still accessible but hidden from the navbar.

use `<basepath>/app/csp_root` to enter
subject to change to `<basepath>/app/csp`