### PR TITLE
fix scroll

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_table.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_table.tsx
@@ -78,7 +78,7 @@ export const FindingsTable = ({ data, status, error, selectItem }: FindingsTable
   );
 };
 
-const RuleName = (name: string) => <EuiLink href="#">{name}</EuiLink>;
+const RuleName = (name: string) => <EuiLink>{name}</EuiLink>;
 const RuleTags = (tags: string[]) => (
   <EuiFlexGroup>
     <EuiFlexItem>


### PR DESCRIPTION
this address issue at 
- https://github.com/elastic/security-team/issues/2575

- [x] scroll doesn't change on item selection 

added a `href=#` for every `<a>` row item, so the browser was trying to scroll to an anchor.

https://user-images.githubusercontent.com/20814186/147260170-ab534b64-511a-40bf-9210-d39f1aa63804.mov

