### PR TITLE
assert on text instead of test-id

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/findings.test.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/findings.test.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 import React from 'react';
-import { Findings } from './findings';
+import { Findings, missingKubebeatErrorMessage } from './findings';
 import { render, screen } from '@testing-library/react';
 import { TestProvider } from '../../application/test_provider';
 import { dataPluginMock } from '../../../../../../src/plugins/data/public/mocks';
@@ -41,7 +41,7 @@ describe('<Findings />', () => {
 
     render(<FindingsComponentWithTestProvider />);
 
-    expect(await screen.findByTestId(TEST_SUBJECTS.FINDINGS_MISSING_INDEX)).toBeInTheDocument();
+    expect(await screen.findByText(missingKubebeatErrorMessage)).toBeInTheDocument();
   });
 
   it("renders the error state component when 'kubebeat' request status is 'error'", async () => {
@@ -49,7 +49,7 @@ describe('<Findings />', () => {
 
     render(<FindingsComponentWithTestProvider />);
 
-    expect(await screen.findByTestId(TEST_SUBJECTS.FINDINGS_MISSING_INDEX)).toBeInTheDocument();
+    expect(await screen.findByText(missingKubebeatErrorMessage)).toBeInTheDocument();
   });
 
   it("renders the success state component when 'kubebeat' DataView exists and request status is 'success'", async () => {

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/findings.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/findings.tsx
@@ -34,6 +34,8 @@ export const Findings = () => {
 
 const LoadingPrompt = () => <EuiEmptyPrompt icon={<EuiLoadingSpinner size="xl" />} />;
 
+export const missingKubebeatErrorMessage = 'Kubebeat DataView is missing';
+
 // TODO: follow https://elastic.github.io/eui/#/display/empty-prompt/guidelines
 const ErrorPrompt = () => (
   <EuiEmptyPrompt
@@ -41,6 +43,6 @@ const ErrorPrompt = () => (
     color="danger"
     iconType="alert"
     // TODO: account for when we have a dataview without an index
-    title={<h2>Kubebeat DataView is missing</h2>}
+    title={<h2>{missingKubebeatErrorMessage}</h2>}
   />
 );


### PR DESCRIPTION
this PR address an issue from 
- https://github.com/build-security/kibana/pull/43#

regarding changing the tests to assert on existence of texts users can see instead of a test-id which is for developers. 

see comment 
- https://github.com/build-security/kibana/pull/43#discussion_r774450906


NOTE: 

`findings.test.ts` includes 3 test cases, this PR changes 2 of them.
the 3rd one is OK to be used with an identifier that is not a text, for now, until we get some more clarifications on the findings table and we know what text to look for, as currently there isn't something we added. 