### PR TITLE
change index pattern from kubebeat* to logs-k8s_cis*

### DIFF
--- a/x-pack/plugins/cloud_security_posture/common/constants.ts
+++ b/x-pack/plugins/cloud_security_posture/common/constants.ts
@@ -4,10 +4,10 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-export const CSP_KUBEBEAT_INDEX_NAME = 'kubebeat*';
+export const CSP_KUBEBEAT_INDEX_NAME = 'logs-k8s_cis*';
 export const CSP_FINDINGS_INDEX_NAME = 'findings';
 export const STATS_ROUTH_PATH = '/api/csp/stats';
 export const FINDINGS_ROUTH_PATH = '/api/csp/finding';
-export const AGENT_LOGS_INDEX = 'kubebeat*';
+export const AGENT_LOGS_INDEX = 'logs-k8s_cis*';
 export const RULE_PASSED = `passed`;
 export const RULE_FAILED = `failed`;


### PR DESCRIPTION
Following this [thread](https://github.com/elastic/security-team/issues/2379) 
The index pattern that the findings looking is `logs-k8s_cis*` instead `kubebeat*`
