### PR TITLE
Findings iter

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_flyout.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_flyout.tsx
@@ -144,7 +144,7 @@ const getResultCards = ({ result, agent, host, ...rest }: CspFinding): Card[] =>
       ['Evidence', <EuiCode>{JSON.stringify(result.evidence, null, 2)}</EuiCode>],
       ['Timestamp', rest['@timestamp']],
       result.evaluation === 'failed' && ['Remediation', rest.rule.remediation],
-    ].filter(Boolean) as Card['listItems'], // TODO: is a type guard,
+    ].filter(Boolean) as Card['listItems'],
   },
   {
     title: 'Agent',


### PR DESCRIPTION
fixes:
- [x] [Remove](https://github.com/build-security/kibana/pull/43#discussion_r774566296)
- [x] [Import search bar](https://github.com/build-security/kibana/pull/43#discussion_r774566521)
- [x] [Type guard comment](https://github.com/build-security/kibana/pull/43#discussion_r774550709)


from:
- https://github.com/elastic/security-team/issues/2587

main change is instead of ignoring a TS error on some prop and assuming it'll work on runtime, we now register to the `filterManager` updates and change URL accordingly so functionality is the same.