### PR TITLE
Findings table states

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_table.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/findings_table.tsx
@@ -12,6 +12,7 @@ import {
   EuiBadgeGroup,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiEmptyPrompt,
   EuiBadge,
   EuiBasicTable,
   PropsOf,
@@ -29,7 +30,7 @@ interface BaseFindingsTableProps {
 
 type FindingsTableProps = FindingsFetchState & BaseFindingsTableProps;
 
-export const FindingsTable = ({ data, status, error, selectItem }: FindingsTableProps) => {
+export const FindingsTable = ({ data = [], status, error, selectItem }: FindingsTableProps) => {
   const [pageIndex, setPageIndex] = useState(0);
   const [pageSize, setPageSize] = useState(25);
 
@@ -54,8 +55,10 @@ export const FindingsTable = ({ data, status, error, selectItem }: FindingsTable
     [data, pageSize, pageIndex]
   );
 
-  // TODO: add empty/error/loading views
-  if (!data) return null;
+  // Show "zero state"
+  if (!data.length && status === 'success')
+    // TODO: use our own logo
+    return <EuiEmptyPrompt iconType="logoKibana" title={<h2>{TEXT.NO_FINDINGS}</h2>} />;
 
   // TODO: async pagination
   const pagination: EuiBasicTableProps<CspFinding>['pagination'] = {

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/translations.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/translations.ts
@@ -145,3 +145,7 @@ export const KERNEL = i18n.translate('xpack.csp.kernel', {
 export const PLATFORM = i18n.translate('xpack.csp.platform', {
   defaultMessage: 'Platform',
 });
+
+export const NO_FINDINGS = i18n.translate('xpack.csp.platform', {
+  defaultMessage: 'There are no Findings',
+});


### PR DESCRIPTION
fixes:
- https://github.com/elastic/security-team/issues/2576

### empty state
the findings page (or any other of our pages) will show the native `kibanaNoData` view, after we merge https://github.com/build-security/kibana/pull/88
this is relevant for cases where we can't find necessities, like our known index, which should've been written already.  
we show this view by using `KibanaPageTemplate`'s `noDataConfig`. same behaviour can be seen in observability (go to any page there without enabling any integration and it will show the empty prompt) 

### zero state
in another case, the index may be available but it is empty. this is called (unofficially AFAIK) a "zero state". so users effectively have no search result. this was added in this PR using `EuiEmptyPromt` and looks like this (for now, pending better designs/copy)

![Screen Shot 2022-01-11 at 19 32 19](https://user-images.githubusercontent.com/20814186/148993641-6173a360-9c76-4099-8088-baba98b688ce.png)

### loading / error state
both are handled by `EuiBasicTable`, and look like this:

loading:
![Screen Shot 2022-01-11 at 19 35 04](https://user-images.githubusercontent.com/20814186/148993837-50a74ee6-8932-4e17-b716-aaf987045f0d.png)


error:
![Screen Shot 2022-01-10 at 17 41 47](https://user-images.githubusercontent.com/20814186/148993882-08358262-0c14-423a-83a7-20b4ae7a95f5.png)



