### PR TITLE
CSP feature flag in kibana's advanced settings

### DIFF
--- a/x-pack/plugins/cloud_security_posture/common/index.ts
+++ b/x-pack/plugins/cloud_security_posture/common/index.ts
@@ -6,4 +6,4 @@
  */
 
 export const PLUGIN_ID = 'csp';
-export const PLUGIN_NAME = 'csp';
+export const PLUGIN_NAME = 'Cloud Security';

--- a/x-pack/plugins/cloud_security_posture/public/plugin.ts
+++ b/x-pack/plugins/cloud_security_posture/public/plugin.ts
@@ -12,8 +12,8 @@ import type {
   CspClientPluginSetupDeps,
   CspClientPluginStartDeps,
 } from './types';
-import { AppNavLinkStatus, AppStatus } from '../../../../src/core/public';
 import { PLUGIN_NAME, PLUGIN_ID } from '../common';
+import { DEFAULT_APP_CATEGORIES } from '../../../../src/core/public';
 
 export class CspPlugin
   implements
@@ -29,21 +29,23 @@ export class CspPlugin
     plugins: CspClientPluginSetup
   ): CspClientPluginSetup {
     // Register an application into the side navigation menu
+    const cspEnabled: boolean = core.uiSettings.get('securitySolution:enableCloudSecurityPosture');
 
-    core.application.register({
-      id: PLUGIN_ID,
-      title: PLUGIN_NAME,
-      status: AppStatus.accessible,
-      navLinkStatus: AppNavLinkStatus.hidden,
-      async mount(params: AppMountParameters) {
-        // Load application bundle
-        const { renderApp } = await import('./application/index');
-        // Get start services as specified in kibana.json
-        const [coreStart, depsStart] = await core.getStartServices();
-        // Render the application
-        return renderApp(coreStart, depsStart, params);
-      },
-    });
+    if (cspEnabled) {
+      core.application.register({
+        id: PLUGIN_ID,
+        title: PLUGIN_NAME,
+        category: DEFAULT_APP_CATEGORIES.security,
+        async mount(params: AppMountParameters) {
+          // Load application bundle
+          const { renderApp } = await import('./application/index');
+          // Get start services as specified in kibana.json
+          const [coreStart, depsStart] = await core.getStartServices();
+          // Render the application
+          return renderApp(coreStart, depsStart, params);
+        },
+      });
+    }
 
     // Return methods that should be available to other plugins
     return {};

--- a/x-pack/plugins/cloud_security_posture/tsconfig.json
+++ b/x-pack/plugins/cloud_security_posture/tsconfig.json
@@ -19,6 +19,7 @@
   "references": [
     { "path": "../../../src/core/tsconfig.json" },
     { "path": "../../../src/plugins/data/tsconfig.json" },
-    { "path": "../../../src/plugins/navigation/tsconfig.json" }
+    { "path": "../../../src/plugins/navigation/tsconfig.json" },
+    { "path": "../security_solution/tsconfig.json" }
   ]
 }

--- a/x-pack/plugins/cloud_security_posture/tsconfig.json
+++ b/x-pack/plugins/cloud_security_posture/tsconfig.json
@@ -20,6 +20,5 @@
     { "path": "../../../src/core/tsconfig.json" },
     { "path": "../../../src/plugins/data/tsconfig.json" },
     { "path": "../../../src/plugins/navigation/tsconfig.json" },
-    { "path": "../security_solution/tsconfig.json" }
   ]
 }

--- a/x-pack/plugins/security_solution/common/constants.ts
+++ b/x-pack/plugins/security_solution/common/constants.ts
@@ -170,6 +170,9 @@ export const DEFAULT_INDEX_PATTERN_EXPERIMENTAL = [
   'ml_host_risk_score_*',
 ];
 
+/** This Kibana Advanced Setting enables the `Cloud Security Posture` beta feature */
+export const ENABLE_CSP = 'securitySolution:enableCloudSecurityPosture' as const;
+
 /** This Kibana Advanced Setting enables the `Security news` feed widget */
 export const ENABLE_NEWS_FEED_SETTING = 'securitySolution:enableNewsFeed' as const;
 

--- a/x-pack/plugins/security_solution/server/ui_settings.ts
+++ b/x-pack/plugins/security_solution/server/ui_settings.ts
@@ -29,6 +29,7 @@ import {
   DEFAULT_TO,
   DEFAULT_TRANSFORMS,
   DEFAULT_TRANSFORMS_SETTING,
+  ENABLE_CSP,
   ENABLE_NEWS_FEED_SETTING,
   IP_REPUTATION_LINKS_SETTING,
   IP_REPUTATION_LINKS_SETTING_DEFAULT,
@@ -135,6 +136,22 @@ export const initUiSettings = (
       category: [APP_ID],
       requiresPageReload: true,
       schema: schema.number(),
+    },
+    [ENABLE_CSP]: {
+      name: i18n.translate('xpack.securitySolution.uiSettings.enableCloudSecurityPosture', {
+        defaultMessage: 'Cloud Security',
+      }),
+      value: false,
+      description: `${i18n.translate(
+        'xpack.securitySolution.uiSettings.enableCloudSecurityPostureDescription',
+        {
+          defaultMessage: '<p>Enables the Cloud Security Posture feature (beta)</p>',
+        }
+      )}`,
+      type: 'boolean',
+      category: [APP_ID],
+      requiresPageReload: true,
+      schema: schema.boolean(),
     },
     [ENABLE_NEWS_FEED_SETTING]: {
       name: i18n.translate('xpack.securitySolution.uiSettings.enableNewsFeedLabel', {


### PR DESCRIPTION
solving https://github.com/elastic/security-team/issues/2612
This PR adds a field into the security solution section in Kibana's advanced settings page.
we only register the plugin in case the feature flag is enabled.
once registered the plugin will join the `Security Solution` category using the `category` prop of the register function.

BE and beta tags were out of scope for this issue. though I did try to see what can be done in those areas and IMO they were indeed a bit too complicated and probably not top priority ATM.