### PR TITLE
Update `stats` api types 

### DIFF
--- a/x-pack/plugins/cloud_security_posture/common/constants.ts
+++ b/x-pack/plugins/cloud_security_posture/common/constants.ts
@@ -17,3 +17,6 @@ export const RULE_FAILED = `failed`;
 export const INTERNAL_FEATURE_FLAGS = {
   benchmarks: false,
 } as const;
+
+/** This Kibana Advanced Setting enables the `Cloud Security Posture` beta feature */
+export const ENABLE_CSP = 'securitySolution:enableCloudSecurityPosture';

--- a/x-pack/plugins/cloud_security_posture/common/types.ts
+++ b/x-pack/plugins/cloud_security_posture/common/types.ts
@@ -10,10 +10,10 @@ export type Evaluation = 'passed' | 'failed' | 'NA';
 export type Score = number;
 
 export interface Stats {
-  postureScore?: Score;
-  totalFindings?: number;
-  totalPassed?: number;
-  totalFailed?: number;
+  postureScore: Score;
+  totalFindings: number;
+  totalPassed: number;
+  totalFailed: number;
 }
 
 export interface BenchmarkStats extends Stats {

--- a/x-pack/plugins/cloud_security_posture/public/plugin.ts
+++ b/x-pack/plugins/cloud_security_posture/public/plugin.ts
@@ -14,7 +14,7 @@ import type {
 } from './types';
 import { PLUGIN_NAME, PLUGIN_ID } from '../common';
 import { DEFAULT_APP_CATEGORIES } from '../../../../src/core/public';
-import { ENABLE_CSP } from '../server/constants';
+import { ENABLE_CSP } from '../common/constants';
 
 export class CspPlugin
   implements

--- a/x-pack/plugins/cloud_security_posture/server/constants.ts
+++ b/x-pack/plugins/cloud_security_posture/server/constants.ts
@@ -8,6 +8,3 @@
 export const RULE_PASSED = `passed`;
 export const RULE_FAILED = `failed`;
 export const SECURITY_SOLUTION_APP_ID = 'securitySolution';
-
-/** This Kibana Advanced Setting enables the `Cloud Security Posture` beta feature */
-export const ENABLE_CSP = 'securitySolution:enableCloudSecurityPosture' as const;

--- a/x-pack/plugins/cloud_security_posture/server/routes/findings/findings.test.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/findings/findings.test.ts
@@ -4,9 +4,8 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-
+// eslint-disable-next-line @kbn/eslint/no-restricted-paths
 import { elasticsearchClientMock } from 'src/core/server/elasticsearch/client/mocks';
-
 import { getLatestCycleIds } from './get_latest_cycle_ids';
 
 const mockEsClient = elasticsearchClientMock.createClusterClient().asScoped().asInternalUser;

--- a/x-pack/plugins/cloud_security_posture/server/routes/stats/stats.test.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/stats/stats.test.ts
@@ -45,15 +45,13 @@ describe('general cloud posture score', () => {
     });
   });
 
-  it('mocking without finding index - expect to undefined from getAllFindingsStats ', async () => {
-    const generalScore = await getAllFindingsStats(mockEsClient, 'randomCycleId');
-    expect(generalScore).toEqual({
-      name: 'general',
-      postureScore: undefined,
-      totalFailed: undefined,
-      totalFindings: undefined,
-      totalPassed: undefined,
-    });
+  it("getAllFindingsStats throws when cycleId doesn't exists", async () => {
+    try {
+      await getAllFindingsStats(mockEsClient, 'randomCycleId');
+    } catch (e) {
+      expect(e).toBeInstanceOf(Error);
+      expect(e.message).toEqual('missing stats');
+    }
   });
 });
 

--- a/x-pack/plugins/cloud_security_posture/server/uiSettings.ts
+++ b/x-pack/plugins/cloud_security_posture/server/uiSettings.ts
@@ -8,7 +8,8 @@
 import { i18n } from '@kbn/i18n';
 import { schema } from '@kbn/config-schema';
 import { CoreSetup } from '../../../../src/core/server';
-import { SECURITY_SOLUTION_APP_ID, ENABLE_CSP } from './constants';
+import { SECURITY_SOLUTION_APP_ID } from './constants';
+import { ENABLE_CSP } from '../common/constants';
 
 export const initUiSettings = (uiSettings: CoreSetup['uiSettings']) => {
   uiSettings.register({


### PR DESCRIPTION
this PR is a **minimal** fix for: 

- [Optional properties in `BenchmarkStats`](https://github.com/build-security/kibana/pull/43#discussion_r773804102)
- TS fixes as we're using deprecated types

issue:
- https://github.com/elastic/security-team/issues/2580

the main fix is simple: if our `stats` is not all numbers, we return an error to FE.

NOTES:

- the `stats` api route needs another iteration. 
- [Empty score representation](https://github.com/build-security/kibana/pull/43#discussion_r773804372)  is not accounted for. 