### PR TITLE
bulk create rules on server start

### DIFF
--- a/x-pack/plugins/cloud_security_posture/common/schemas/csp_rule.ts
+++ b/x-pack/plugins/cloud_security_posture/common/schemas/csp_rule.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { schema as rt, TypeOf } from '@kbn/config-schema';
+
+export const cspRuleAssetSavedObjectType = 'csp_rule';
+
+// TODO: needs to be shared with kubebeat
+export const cspRuleSchema = rt.object({
+  id: rt.string(),
+  name: rt.string(),
+  description: rt.string(),
+  rationale: rt.string(),
+  impact: rt.string(),
+  default_value: rt.string(),
+  remediation: rt.string(),
+  benchmark: rt.object({ name: rt.string(), version: rt.string() }),
+  tags: rt.arrayOf(rt.string()),
+  enabled: rt.boolean(),
+  muted: rt.boolean(),
+});
+
+export type CspRuleSchema = TypeOf<typeof cspRuleSchema>;

--- a/x-pack/plugins/cloud_security_posture/server/plugin.ts
+++ b/x-pack/plugins/cloud_security_posture/server/plugin.ts
@@ -21,6 +21,8 @@ import type {
 } from './types';
 import { defineRoutes } from './routes';
 import { initUiSettings } from './ui_settings';
+import { cspRuleAssetType } from './saved_objects/cis_1_4_1/csp_rule_type';
+import { initializeCspRules } from './saved_objects/cis_1_4_1/initialize_rules';
 
 export class CspPlugin
   implements
@@ -41,6 +43,9 @@ export class CspPlugin
     plugins: CspServerPluginSetupDeps
   ): CspServerPluginSetup {
     this.logger.debug('csp: Setup');
+
+    core.savedObjects.registerType(cspRuleAssetType);
+
     const router = core.http.createRouter();
 
     // Register server side APIs
@@ -55,6 +60,9 @@ export class CspPlugin
     createFindingsIndexTemplate(core.elasticsearch.client.asInternalUser, this.logger).catch(
       this.logger.error
     );
+
+    initializeCspRules(core.savedObjects.createInternalRepository());
+
     return {};
   }
   public stop() {}

--- a/x-pack/plugins/cloud_security_posture/server/saved_objects/cis_1_4_1/csp_rule_type.ts
+++ b/x-pack/plugins/cloud_security_posture/server/saved_objects/cis_1_4_1/csp_rule_type.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+import type {
+  SavedObjectsType,
+  SavedObjectsValidationMap,
+} from '../../../../../../src/core/server';
+import {
+  type CspRuleSchema,
+  cspRuleSchema,
+  cspRuleAssetSavedObjectType,
+} from '../../../common/schemas/csp_rule';
+
+const validationMap: SavedObjectsValidationMap = {
+  '1.0.0': cspRuleSchema,
+};
+
+export const ruleAssetSavedObjectMappings: SavedObjectsType<CspRuleSchema>['mappings'] = {
+  dynamic: false,
+  properties: {
+    name: {
+      type: 'text', // search
+      fields: {
+        // TODO: how is fields mapping shared with UI ?
+        raw: {
+          type: 'keyword', // sort
+        },
+      },
+    },
+    description: {
+      type: 'text',
+    },
+  },
+};
+
+export const cspRuleAssetType: SavedObjectsType<CspRuleSchema> = {
+  name: cspRuleAssetSavedObjectType,
+  hidden: false,
+  namespaceType: 'agnostic',
+  mappings: ruleAssetSavedObjectMappings,
+  schemas: validationMap,
+  // migrations: {}
+  management: {
+    importableAndExportable: true,
+    visibleInManagement: true,
+    getTitle: (savedObject) =>
+      `${i18n.translate('xpack.csp.cspSettings.rules', {
+        defaultMessage: `CSP Security Rules - `,
+      })} ${savedObject.attributes.benchmark.name} ${savedObject.attributes.benchmark.version} ${
+        savedObject.attributes.name
+      }`,
+  },
+};

--- a/x-pack/plugins/cloud_security_posture/server/saved_objects/cis_1_4_1/initialize_rules.ts
+++ b/x-pack/plugins/cloud_security_posture/server/saved_objects/cis_1_4_1/initialize_rules.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ISavedObjectsRepository } from 'src/core/server';
+import { CIS_BENCHMARK_1_4_1_RULES } from './rules';
+import { cspRuleAssetSavedObjectType } from '../../../common/schemas/csp_rule';
+
+export const initializeCspRules = async (client: ISavedObjectsRepository) => {
+  const existingRules = await client.find({ type: cspRuleAssetSavedObjectType, perPage: 1 });
+
+  // TODO: version?
+  if (existingRules.total !== 0) return;
+
+  try {
+    await client.bulkCreate(CIS_BENCHMARK_1_4_1_RULES);
+  } catch (e) {
+    // TODO: add logger
+    // TODO: handle error
+  }
+};

--- a/x-pack/plugins/cloud_security_posture/server/saved_objects/cis_1_4_1/rules.ts
+++ b/x-pack/plugins/cloud_security_posture/server/saved_objects/cis_1_4_1/rules.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { SavedObjectsBulkCreateObject } from 'src/core/server';
+import type { CspRuleSchema } from '../../../common/schemas/csp_rule';
+import { cspRuleAssetSavedObjectType } from '../../../common/schemas/csp_rule';
+
+const benchmark = { name: 'CIS', version: '1.4.1' } as const;
+
+const RULES: CspRuleSchema[] = [
+  {
+    id: '1.1.1',
+    name: 'Ensure that the API server pod specification file permissions are set to 644 or more restrictive (Automated)',
+    description: 'Disable anonymous requests to the API server',
+    rationale:
+      'When enabled, requests that are not rejected by other configured authentication methods\nare treated as anonymous requests. These requests are then served by the API server. You\nshould rely on authentication to authorize access and disallow anonymous requests.\nIf you are using RBAC authorization, it is generally considered reasonable to allow\nanonymous access to the API Server for health checks and discovery purposes, and hence\nthis recommendation is not scored. However, you should consider whether anonymous\ndiscovery is an acceptable risk for your purposes.',
+    impact: 'Anonymous requests will be rejected.',
+    default_value: 'By default, anonymous access is enabled.',
+    remediation:
+      'Edit the API server pod specification file /etc/kubernetes/manifests/kubeapiserver.yaml on the master node and set the below parameter.\n--anonymous-auth=false',
+    tags: [],
+    enabled: true,
+    muted: false,
+    benchmark,
+  },
+  {
+    id: '1.1.2',
+    name: 'Ensure that the --basic-auth-file argument is not set (Scored)',
+    description: 'Do not use basic authentication',
+    rationale:
+      'Basic authentication uses plaintext credentials for authentication. Currently, the basic\nauthentication credentials last indefinitely, and the password cannot be changed without\nrestarting API server. The basic authentication is currently supported for convenience.\nHence, basic authentication should not be used',
+    impact:
+      'You will have to configure and use alternate authentication mechanisms such as tokens and\ncertificates. Username and password for basic authentication could no longer be used.',
+    default_value: 'By default, basic authentication is not set',
+    remediation:
+      'Follow the documentation and configure alternate mechanisms for authentication. Then,\nedit the API server pod specification file /etc/kubernetes/manifests/kubeapiserver.yaml on the master node and remove the --basic-auth-file=<filename>\nparameter.',
+    tags: [],
+    enabled: true,
+    muted: false,
+    benchmark,
+  },
+];
+
+export const CIS_BENCHMARK_1_4_1_RULES: Array<SavedObjectsBulkCreateObject<CspRuleSchema>> =
+  RULES.map((rule) => ({
+    attributes: rule,
+    id: rule.id,
+    type: cspRuleAssetSavedObjectType,
+  }));


### PR DESCRIPTION
WIP 
----

this PR is mostly a POC of how we could preload json data (`CIS Benchmark` in our case) into a new saved object type we define, so the UI can query it.

done as part of: 
- https://github.com/elastic/security-team/issues/2764

includes:

- [x] define a `CspRuleSchema` (based on [prior work](https://github.com/elastic/security-team/blob/main/docs/cloud-security-posture-team/Onboarding/Security%20Policies.md)) on plugin `setup`
- [x] define 2 static rules based on the schema
- [x] register a new saved object type on plugin `start`:
  - [x]  define attributes schema (enforced on `create`)
  - [ ]   define migrations 
  - [x]   define properties mapping for searching / sorting
