### PR TITLE
Add benchmarks page UI (mock data)

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/common/navigation/constants.ts
+++ b/x-pack/plugins/cloud_security_posture/public/common/navigation/constants.ts
@@ -13,7 +13,7 @@ export const allNavigationItems: Record<CspPage, CspNavigationItem> = {
   dashboard: { name: TEXT.DASHBOARD, path: '/dashboard' },
   findings: { name: TEXT.FINDINGS, path: '/findings' },
   benchmarks: {
-    name: TEXT.BENCHMARKS,
+    name: TEXT.MY_BENCHMARKS,
     path: '/benchmarks',
     disabled: !INTERNAL_FEATURE_FLAGS.benchmarks,
   },

--- a/x-pack/plugins/cloud_security_posture/public/common/navigation/translations.ts
+++ b/x-pack/plugins/cloud_security_posture/public/common/navigation/translations.ts
@@ -19,6 +19,6 @@ export const DASHBOARD = i18n.translate('xpack.csp.navigation.dashboard', {
   defaultMessage: 'Dashboard',
 });
 
-export const BENCHMARKS = i18n.translate('xpack.csp.navigation.benchmarks', {
+export const MY_BENCHMARKS = i18n.translate('xpack.csp.navigation.my_benchmarks', {
   defaultMessage: 'My Benchmarks',
 });

--- a/x-pack/plugins/cloud_security_posture/public/common/navigation/translations.ts
+++ b/x-pack/plugins/cloud_security_posture/public/common/navigation/translations.ts
@@ -20,5 +20,5 @@ export const DASHBOARD = i18n.translate('xpack.csp.navigation.dashboard', {
 });
 
 export const BENCHMARKS = i18n.translate('xpack.csp.navigation.benchmarks', {
-  defaultMessage: 'Benchmarks',
+  defaultMessage: 'My Benchmarks',
 });

--- a/x-pack/plugins/cloud_security_posture/public/components/csp_loading_state.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/csp_loading_state.tsx
@@ -8,15 +8,11 @@
 import { EuiFlexGroup, EuiFlexItem, EuiLoadingSpinner } from '@elastic/eui';
 import React from 'react';
 
-interface CspLoadingStateProps {
-  loadingText?: string;
-}
-
-export const CspLoadingState = ({ loadingText = 'Loading...' }: CspLoadingStateProps) => (
-  <EuiFlexGroup direction="column" alignItems="center" style={{ marginTop: '10vh' }}>
+export const CspLoadingState: React.FunctionComponent = ({ children }) => (
+  <EuiFlexGroup direction="column" alignItems="center">
     <EuiFlexItem>
       <EuiLoadingSpinner size="xl" />
     </EuiFlexItem>
-    <EuiFlexItem>{loadingText}</EuiFlexItem>
+    <EuiFlexItem>{children}</EuiFlexItem>
   </EuiFlexGroup>
 );

--- a/x-pack/plugins/cloud_security_posture/public/components/csp_loading_state.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/csp_loading_state.tsx
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiFlexGroup, EuiFlexItem, EuiLoadingSpinner } from '@elastic/eui';
+import React from 'react';
+
+interface CspLoadingStateProps {
+  loadingText?: string;
+}
+
+export const CspLoadingState = ({ loadingText = 'Loading...' }: CspLoadingStateProps) => (
+  <EuiFlexGroup direction="column" alignItems="center" style={{ marginTop: '10vh' }}>
+    <EuiFlexItem>
+      <EuiLoadingSpinner size="xl" />
+    </EuiFlexItem>
+    <EuiFlexItem>{loadingText}</EuiFlexItem>
+  </EuiFlexGroup>
+);

--- a/x-pack/plugins/cloud_security_posture/public/components/page_template.test.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/page_template.test.tsx
@@ -4,9 +4,12 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+import React, { ComponentProps } from 'react';
+import { render, screen } from '@testing-library/react';
 import Chance from 'chance';
 import { createNavigationItemFixture } from '../test/fixtures/navigationItem';
-import { getSideNavItems } from './page_template';
+import { TestProvider } from '../test/test_provider';
+import { CspPageTemplate, getSideNavItems } from './page_template';
 
 const chance = new Chance();
 
@@ -29,5 +32,44 @@ describe('getSideNavItems', () => {
     const id = chance.word();
     const sideNavItems = getSideNavItems({ [id]: navigationItem });
     expect(sideNavItems).toHaveLength(0);
+  });
+});
+
+describe('<CspPageTemplate />', () => {
+  const renderCspPageTemplate = (props: ComponentProps<typeof CspPageTemplate>) => {
+    render(
+      <TestProvider>
+        <CspPageTemplate {...props} />
+      </TestProvider>
+    );
+  };
+
+  it('renders children when not loading', () => {
+    const children = chance.sentence();
+    renderCspPageTemplate({ isLoading: false, children });
+
+    expect(screen.getByText(children)).toBeInTheDocument();
+  });
+
+  it('does not render loading text when not loading', () => {
+    const children = chance.sentence();
+    const loadingText = chance.sentence();
+    renderCspPageTemplate({ isLoading: false, loadingText, children });
+
+    expect(screen.queryByText(loadingText)).not.toBeInTheDocument();
+  });
+
+  it('renders loading text when loading is true', () => {
+    const loadingText = chance.sentence();
+    renderCspPageTemplate({ loadingText, isLoading: true });
+
+    expect(screen.getByText(loadingText)).toBeInTheDocument();
+  });
+
+  it('does not render children when loading', () => {
+    const children = chance.sentence();
+    renderCspPageTemplate({ isLoading: true, children });
+
+    expect(screen.queryByText(children)).not.toBeInTheDocument();
   });
 });

--- a/x-pack/plugins/cloud_security_posture/public/components/page_template.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/page_template.tsx
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { EuiSpacer } from '@elastic/eui';
 import React from 'react';
 import { NavLink } from 'react-router-dom';
 import { EuiErrorBoundary } from '@elastic/eui';
@@ -15,6 +16,8 @@ import {
 import { allNavigationItems } from '../common/navigation/constants';
 import type { CspNavigationItem } from '../common/navigation/types';
 import { CLOUD_SECURITY_POSTURE } from '../common/translations';
+import { CspLoadingState } from './csp_loading_state';
+import { LOADING } from './translations';
 
 const activeItemStyle = { fontWeight: 700 };
 
@@ -42,10 +45,29 @@ const defaultProps: KibanaPageTemplateProps = {
   template: 'default',
 };
 
-export const CspPageTemplate: React.FC<KibanaPageTemplateProps> = ({ children, ...props }) => {
+interface CspPageTemplateProps extends KibanaPageTemplateProps {
+  isLoading?: boolean;
+  loadingText?: string;
+}
+
+export const CspPageTemplate: React.FC<CspPageTemplateProps> = ({
+  children,
+  isLoading,
+  loadingText = LOADING,
+  ...props
+}) => {
   return (
     <KibanaPageTemplate {...defaultProps} {...props}>
-      <EuiErrorBoundary>{children}</EuiErrorBoundary>
+      <EuiErrorBoundary>
+        {isLoading ? (
+          <>
+            <EuiSpacer size="xxl" />
+            <CspLoadingState>{loadingText}</CspLoadingState>
+          </>
+        ) : (
+          children
+        )}
+      </EuiErrorBoundary>
     </KibanaPageTemplate>
   );
 };

--- a/x-pack/plugins/cloud_security_posture/public/components/translations.ts
+++ b/x-pack/plugins/cloud_security_posture/public/components/translations.ts
@@ -22,3 +22,7 @@ export const HEALTHY = i18n.translate('xpack.csp.healthy', {
 export const PAGE_NOT_FOUND = i18n.translate('xpack.csp.page_not_found', {
   defaultMessage: 'Page not found',
 });
+
+export const LOADING = i18n.translate('xpack.csp.loading', {
+  defaultMessage: 'Loading...',
+});

--- a/x-pack/plugins/cloud_security_posture/public/pages/benchmarks/benchmarks.test.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/benchmarks/benchmarks.test.tsx
@@ -11,7 +11,7 @@ import { createCspBenchmarkIntegrationFixture } from '../../test/fixtures/csp_be
 import { createReactQueryResponse } from '../../test/fixtures/react_query';
 import { TestProvider } from '../../test/test_provider';
 import { Benchmarks, BENCHMARKS_ERROR_TEXT, BENCHMARKS_TABLE_DATA_TEST_SUBJ } from './benchmarks';
-import { ADD_CIS_INTEGRATION, BENCHMARK_INTEGRATIONS, LOADING_BENCHMARKS } from './translations';
+import { ADD_A_CIS_INTEGRATION, BENCHMARK_INTEGRATIONS, LOADING_BENCHMARKS } from './translations';
 import { useCspBenchmarkIntegrations } from './use_csp_benchmark_integrations';
 
 jest.mock('./use_csp_benchmark_integrations');
@@ -21,10 +21,8 @@ describe('<Benchmarks />', () => {
     jest.resetAllMocks();
   });
 
-  const renderBenchmarks = (queryResponse?: UseQueryResult) => {
-    (useCspBenchmarkIntegrations as jest.Mock).mockImplementation(
-      () => queryResponse ?? createReactQueryResponse()
-    );
+  const renderBenchmarks = (queryResponse: UseQueryResult = createReactQueryResponse()) => {
+    (useCspBenchmarkIntegrations as jest.Mock).mockImplementation(() => queryResponse);
 
     return render(
       <TestProvider>
@@ -42,7 +40,7 @@ describe('<Benchmarks />', () => {
   it('renders the "add integration" button', () => {
     renderBenchmarks();
 
-    expect(screen.getByText(ADD_CIS_INTEGRATION)).toBeInTheDocument();
+    expect(screen.getByText(ADD_A_CIS_INTEGRATION)).toBeInTheDocument();
   });
 
   it('renders loading state while loading', () => {
@@ -53,7 +51,7 @@ describe('<Benchmarks />', () => {
   });
 
   it('renders error state while there is an error', () => {
-    renderBenchmarks(createReactQueryResponse({ status: 'error' }));
+    renderBenchmarks(createReactQueryResponse({ status: 'error', error: new Error() }));
 
     expect(screen.getByText(BENCHMARKS_ERROR_TEXT)).toBeInTheDocument();
     expect(screen.queryByTestId(BENCHMARKS_TABLE_DATA_TEST_SUBJ)).not.toBeInTheDocument();

--- a/x-pack/plugins/cloud_security_posture/public/pages/benchmarks/benchmarks.test.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/benchmarks/benchmarks.test.tsx
@@ -1,0 +1,72 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import type { UseQueryResult } from 'react-query/types/react/types';
+import { createCspBenchmarkIntegrationFixture } from '../../test/fixtures/csp_benchmark_integration';
+import { createReactQueryResponse } from '../../test/fixtures/react_query';
+import { TestProvider } from '../../test/test_provider';
+import { Benchmarks, BENCHMARKS_ERROR_TEXT, BENCHMARKS_TABLE_DATA_TEST_SUBJ } from './benchmarks';
+import { ADD_CIS_INTEGRATION, BENCHMARK_INTEGRATIONS, LOADING_BENCHMARKS } from './translations';
+import { useCspBenchmarkIntegrations } from './use_csp_benchmark_integrations';
+
+jest.mock('./use_csp_benchmark_integrations');
+
+describe('<Benchmarks />', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  const renderBenchmarks = (queryResponse?: UseQueryResult) => {
+    (useCspBenchmarkIntegrations as jest.Mock).mockImplementation(
+      () => queryResponse ?? createReactQueryResponse()
+    );
+
+    return render(
+      <TestProvider>
+        <Benchmarks />
+      </TestProvider>
+    );
+  };
+
+  it('renders the page header', () => {
+    renderBenchmarks();
+
+    expect(screen.getByText(BENCHMARK_INTEGRATIONS)).toBeInTheDocument();
+  });
+
+  it('renders the "add integration" button', () => {
+    renderBenchmarks();
+
+    expect(screen.getByText(ADD_CIS_INTEGRATION)).toBeInTheDocument();
+  });
+
+  it('renders loading state while loading', () => {
+    renderBenchmarks(createReactQueryResponse({ status: 'loading' }));
+
+    expect(screen.getByText(LOADING_BENCHMARKS)).toBeInTheDocument();
+    expect(screen.queryByTestId(BENCHMARKS_TABLE_DATA_TEST_SUBJ)).not.toBeInTheDocument();
+  });
+
+  it('renders error state while there is an error', () => {
+    renderBenchmarks(createReactQueryResponse({ status: 'error' }));
+
+    expect(screen.getByText(BENCHMARKS_ERROR_TEXT)).toBeInTheDocument();
+    expect(screen.queryByTestId(BENCHMARKS_TABLE_DATA_TEST_SUBJ)).not.toBeInTheDocument();
+  });
+
+  it('renders the benchmarks table', () => {
+    renderBenchmarks(
+      createReactQueryResponse({
+        status: 'success',
+        data: [createCspBenchmarkIntegrationFixture()],
+      })
+    );
+
+    expect(screen.getByTestId(BENCHMARKS_TABLE_DATA_TEST_SUBJ)).toBeInTheDocument();
+  });
+});

--- a/x-pack/plugins/cloud_security_posture/public/pages/benchmarks/benchmarks.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/benchmarks/benchmarks.tsx
@@ -8,7 +8,6 @@ import { EuiPageHeaderProps, EuiButton } from '@elastic/eui';
 import React from 'react';
 import { allNavigationItems } from '../../common/navigation/constants';
 import { useCspBreadcrumbs } from '../../common/navigation/use_csp_breadcrumbs';
-import { CspLoadingState } from '../../components/csp_loading_state';
 import { CspPageTemplate } from '../../components/page_template';
 import { BenchmarksTable } from './benchmarks_table';
 import { ADD_A_CIS_INTEGRATION, BENCHMARK_INTEGRATIONS, LOADING_BENCHMARKS } from './translations';
@@ -17,7 +16,7 @@ import { useCspBenchmarkIntegrations } from './use_csp_benchmark_integrations';
 const PAGE_HEADER: EuiPageHeaderProps = {
   pageTitle: BENCHMARK_INTEGRATIONS,
   rightSideItems: [
-    // TODO: Link this to integrations once we have one
+    // TODO: Link this to integrations once we have one https://github.com/elastic/security-team/issues/2940
     <EuiButton fill iconType="plusInCircle">
       {ADD_A_CIS_INTEGRATION}
     </EuiButton>,
@@ -34,8 +33,11 @@ export const Benchmarks = () => {
   const query = useCspBenchmarkIntegrations();
 
   return (
-    <CspPageTemplate pageHeader={PAGE_HEADER}>
-      {query.status === 'loading' && <CspLoadingState loadingText={LOADING_BENCHMARKS} />}
+    <CspPageTemplate
+      pageHeader={PAGE_HEADER}
+      loadingText={LOADING_BENCHMARKS}
+      isLoading={query.status === 'loading'}
+    >
       {query.status === 'error' && <BenchmarksErrorState />}
       {query.status === 'success' && (
         <BenchmarksTable benchmarks={query.data} data-test-subj={BENCHMARKS_TABLE_DATA_TEST_SUBJ} />

--- a/x-pack/plugins/cloud_security_posture/public/pages/benchmarks/benchmarks.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/benchmarks/benchmarks.tsx
@@ -4,6 +4,42 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+import { EuiPageHeaderProps, EuiButton } from '@elastic/eui';
 import React from 'react';
+import { allNavigationItems } from '../../common/navigation/constants';
+import { useCspBreadcrumbs } from '../../common/navigation/use_csp_breadcrumbs';
+import { CspLoadingState } from '../../components/csp_loading_state';
+import { CspPageTemplate } from '../../components/page_template';
+import { BenchmarksTable } from './benchmarks_table';
+import { ADD_CIS_INTEGRATION, BENCHMARK_INTEGRATIONS, LOADING_BENCHMARKS } from './translations';
+import { useCspBenchmarkIntegrations } from './use_csp_benchmark_integrations';
 
-export const Benchmarks = () => <div>Hello world</div>;
+const PAGE_HEADER: EuiPageHeaderProps = {
+  pageTitle: BENCHMARK_INTEGRATIONS,
+  rightSideItems: [
+    // TODO: Link this to integrations once we have one
+    <EuiButton fill iconType="plusInCircle">
+      {ADD_CIS_INTEGRATION}
+    </EuiButton>,
+  ],
+};
+
+export const BENCHMARKS_TABLE_DATA_TEST_SUBJ = 'cspBenchmarksTable';
+// TODO: Error state
+export const BENCHMARKS_ERROR_TEXT = 'TODO: Error state';
+const BenchmarksErrorState = () => <div>{BENCHMARKS_ERROR_TEXT}</div>;
+
+export const Benchmarks = () => {
+  useCspBreadcrumbs([allNavigationItems.benchmarks]);
+  const query = useCspBenchmarkIntegrations();
+
+  return (
+    <CspPageTemplate pageHeader={PAGE_HEADER}>
+      {query.status === 'loading' && <CspLoadingState loadingText={LOADING_BENCHMARKS} />}
+      {query.status === 'error' && <BenchmarksErrorState />}
+      {query.status === 'success' && (
+        <BenchmarksTable benchmarks={query.data} data-test-subj={BENCHMARKS_TABLE_DATA_TEST_SUBJ} />
+      )}
+    </CspPageTemplate>
+  );
+};

--- a/x-pack/plugins/cloud_security_posture/public/pages/benchmarks/benchmarks.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/benchmarks/benchmarks.tsx
@@ -11,7 +11,7 @@ import { useCspBreadcrumbs } from '../../common/navigation/use_csp_breadcrumbs';
 import { CspLoadingState } from '../../components/csp_loading_state';
 import { CspPageTemplate } from '../../components/page_template';
 import { BenchmarksTable } from './benchmarks_table';
-import { ADD_CIS_INTEGRATION, BENCHMARK_INTEGRATIONS, LOADING_BENCHMARKS } from './translations';
+import { ADD_A_CIS_INTEGRATION, BENCHMARK_INTEGRATIONS, LOADING_BENCHMARKS } from './translations';
 import { useCspBenchmarkIntegrations } from './use_csp_benchmark_integrations';
 
 const PAGE_HEADER: EuiPageHeaderProps = {
@@ -19,7 +19,7 @@ const PAGE_HEADER: EuiPageHeaderProps = {
   rightSideItems: [
     // TODO: Link this to integrations once we have one
     <EuiButton fill iconType="plusInCircle">
-      {ADD_CIS_INTEGRATION}
+      {ADD_A_CIS_INTEGRATION}
     </EuiButton>,
   ],
 };

--- a/x-pack/plugins/cloud_security_posture/public/pages/benchmarks/benchmarks_table.test.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/benchmarks/benchmarks_table.test.tsx
@@ -1,0 +1,103 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React from 'react';
+import Chance from 'chance';
+import { render, screen } from '@testing-library/react';
+import moment from 'moment';
+import { createCspBenchmarkIntegrationFixture } from '../../test/fixtures/csp_benchmark_integration';
+import { BenchmarksTable } from './benchmarks_table';
+import { TABLE_COLUMN_HEADERS } from './translations';
+
+describe('<BenchmarksTable />', () => {
+  const chance = new Chance();
+
+  it('renders all column headers', () => {
+    render(<BenchmarksTable benchmarks={[]} />);
+
+    Object.values(TABLE_COLUMN_HEADERS).forEach((columnHeader) => {
+      expect(screen.getByText(columnHeader)).toBeInTheDocument();
+    });
+  });
+
+  it('renders integration name', () => {
+    const integrationName = chance.sentence();
+    const benchmarks = [
+      createCspBenchmarkIntegrationFixture({ integration_name: integrationName }),
+    ];
+
+    render(<BenchmarksTable benchmarks={benchmarks} />);
+
+    expect(screen.getByText(integrationName)).toBeInTheDocument();
+  });
+
+  it('renders benchmark name', () => {
+    const benchmarkName = chance.sentence();
+    const benchmarks = [createCspBenchmarkIntegrationFixture({ benchmark: benchmarkName })];
+
+    render(<BenchmarksTable benchmarks={benchmarks} />);
+
+    expect(screen.getByText(benchmarkName)).toBeInTheDocument();
+  });
+
+  it('renders active rules', () => {
+    const activeRules = chance.integer({ min: 1 });
+    const totalRules = chance.integer({ min: activeRules });
+    const benchmarks = [
+      createCspBenchmarkIntegrationFixture({ rules: { active: activeRules, total: totalRules } }),
+    ];
+
+    render(<BenchmarksTable benchmarks={benchmarks} />);
+
+    expect(screen.getByText(`${activeRules} of ${totalRules}`)).toBeInTheDocument();
+  });
+
+  it('renders agent policy name', () => {
+    const agentPolicy = {
+      id: chance.guid(),
+      name: chance.sentence(),
+      number_of_agents: chance.integer({ min: 1 }),
+    };
+
+    const benchmarks = [createCspBenchmarkIntegrationFixture({ agent_policy: agentPolicy })];
+
+    render(<BenchmarksTable benchmarks={benchmarks} />);
+
+    expect(screen.getByText(agentPolicy.name)).toBeInTheDocument();
+  });
+
+  it('renders number of agents', () => {
+    const agentPolicy = {
+      id: chance.guid(),
+      name: chance.sentence(),
+      number_of_agents: chance.integer({ min: 1 }),
+    };
+
+    const benchmarks = [createCspBenchmarkIntegrationFixture({ agent_policy: agentPolicy })];
+
+    render(<BenchmarksTable benchmarks={benchmarks} />);
+
+    expect(screen.getByText(agentPolicy.number_of_agents)).toBeInTheDocument();
+  });
+
+  it('renders created by', () => {
+    const createdBy = chance.sentence();
+    const benchmarks = [createCspBenchmarkIntegrationFixture({ created_by: createdBy })];
+
+    render(<BenchmarksTable benchmarks={benchmarks} />);
+
+    expect(screen.getByText(createdBy)).toBeInTheDocument();
+  });
+
+  it('renders created at', () => {
+    const createdAt = chance.date({ year: chance.integer({ min: 2015, max: 2021 }) }) as Date;
+    const benchmarks = [createCspBenchmarkIntegrationFixture({ created_at: createdAt })];
+
+    render(<BenchmarksTable benchmarks={benchmarks} />);
+
+    expect(screen.getByText(moment(createdAt).fromNow())).toBeInTheDocument();
+  });
+});

--- a/x-pack/plugins/cloud_security_posture/public/pages/benchmarks/benchmarks_table.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/benchmarks/benchmarks_table.tsx
@@ -1,0 +1,62 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiBasicTable } from '@elastic/eui';
+import React from 'react';
+import moment from 'moment';
+import { TABLE_COLUMN_HEADERS } from './translations';
+import type { CspBenchmarkIntegration } from './types';
+
+interface BenchmarksTableProps {
+  benchmarks: CspBenchmarkIntegration[];
+  'data-test-subj'?: string;
+}
+
+export const BenchmarksTable = ({ benchmarks, ...rest }: BenchmarksTableProps) => (
+  <EuiBasicTable
+    data-test-subj={rest['data-test-subj']}
+    items={benchmarks}
+    columns={[
+      {
+        field: 'integration_name',
+        name: TABLE_COLUMN_HEADERS.INTEGRATION_NAME,
+        dataType: 'string',
+      },
+      {
+        field: 'benchmark',
+        name: TABLE_COLUMN_HEADERS.BENCHMARK,
+        dataType: 'string',
+      },
+      {
+        render: (benchmarkIntegration: CspBenchmarkIntegration) =>
+          `${benchmarkIntegration.rules.active} of ${benchmarkIntegration.rules.total}`,
+        name: TABLE_COLUMN_HEADERS.ACTIVE_RULES,
+      },
+      {
+        field: 'agent_policy.name',
+        name: TABLE_COLUMN_HEADERS.AGENT_POLICY,
+        dataType: 'string',
+      },
+      {
+        field: 'agent_policy.number_of_agents',
+        name: TABLE_COLUMN_HEADERS.NUMBER_OF_AGENTS,
+        dataType: 'number',
+      },
+      {
+        field: 'created_by',
+        name: TABLE_COLUMN_HEADERS.CREATED_BY,
+        dataType: 'string',
+      },
+      {
+        field: 'created_at',
+        name: TABLE_COLUMN_HEADERS.CREATED_AT,
+        dataType: 'date',
+        render: (date: CspBenchmarkIntegration['created_at']) => moment(date).fromNow(),
+      },
+    ]}
+  />
+);

--- a/x-pack/plugins/cloud_security_posture/public/pages/benchmarks/benchmarks_table.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/benchmarks/benchmarks_table.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { EuiBasicTable } from '@elastic/eui';
+import { EuiBasicTable, type EuiBasicTableColumn } from '@elastic/eui';
 import React from 'react';
 import moment from 'moment';
 import { TABLE_COLUMN_HEADERS } from './translations';
@@ -16,47 +16,49 @@ interface BenchmarksTableProps {
   'data-test-subj'?: string;
 }
 
+const BENCHMARKS_TABLE_COLUMNS: Array<EuiBasicTableColumn<CspBenchmarkIntegration>> = [
+  {
+    field: 'integration_name',
+    name: TABLE_COLUMN_HEADERS.INTEGRATION_NAME,
+    dataType: 'string',
+  },
+  {
+    field: 'benchmark',
+    name: TABLE_COLUMN_HEADERS.BENCHMARK,
+    dataType: 'string',
+  },
+  {
+    render: (benchmarkIntegration: CspBenchmarkIntegration) =>
+      `${benchmarkIntegration.rules.active} of ${benchmarkIntegration.rules.total}`,
+    name: TABLE_COLUMN_HEADERS.ACTIVE_RULES,
+  },
+  {
+    field: 'agent_policy.name',
+    name: TABLE_COLUMN_HEADERS.AGENT_POLICY,
+    dataType: 'string',
+  },
+  {
+    field: 'agent_policy.number_of_agents',
+    name: TABLE_COLUMN_HEADERS.NUMBER_OF_AGENTS,
+    dataType: 'number',
+  },
+  {
+    field: 'created_by',
+    name: TABLE_COLUMN_HEADERS.CREATED_BY,
+    dataType: 'string',
+  },
+  {
+    field: 'created_at',
+    name: TABLE_COLUMN_HEADERS.CREATED_AT,
+    dataType: 'date',
+    render: (date: CspBenchmarkIntegration['created_at']) => moment(date).fromNow(),
+  },
+];
+
 export const BenchmarksTable = ({ benchmarks, ...rest }: BenchmarksTableProps) => (
   <EuiBasicTable
     data-test-subj={rest['data-test-subj']}
     items={benchmarks}
-    columns={[
-      {
-        field: 'integration_name',
-        name: TABLE_COLUMN_HEADERS.INTEGRATION_NAME,
-        dataType: 'string',
-      },
-      {
-        field: 'benchmark',
-        name: TABLE_COLUMN_HEADERS.BENCHMARK,
-        dataType: 'string',
-      },
-      {
-        render: (benchmarkIntegration: CspBenchmarkIntegration) =>
-          `${benchmarkIntegration.rules.active} of ${benchmarkIntegration.rules.total}`,
-        name: TABLE_COLUMN_HEADERS.ACTIVE_RULES,
-      },
-      {
-        field: 'agent_policy.name',
-        name: TABLE_COLUMN_HEADERS.AGENT_POLICY,
-        dataType: 'string',
-      },
-      {
-        field: 'agent_policy.number_of_agents',
-        name: TABLE_COLUMN_HEADERS.NUMBER_OF_AGENTS,
-        dataType: 'number',
-      },
-      {
-        field: 'created_by',
-        name: TABLE_COLUMN_HEADERS.CREATED_BY,
-        dataType: 'string',
-      },
-      {
-        field: 'created_at',
-        name: TABLE_COLUMN_HEADERS.CREATED_AT,
-        dataType: 'date',
-        render: (date: CspBenchmarkIntegration['created_at']) => moment(date).fromNow(),
-      },
-    ]}
+    columns={BENCHMARKS_TABLE_COLUMNS}
   />
 );

--- a/x-pack/plugins/cloud_security_posture/public/pages/benchmarks/translations.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/benchmarks/translations.ts
@@ -18,7 +18,7 @@ export const LOADING_BENCHMARKS = i18n.translate('xpack.csp.benchmarks.loading_b
   defaultMessage: 'Loading your benchmarks...',
 });
 
-export const ADD_CIS_INTEGRATION = i18n.translate('xpack.csp.benchmarks.add_cis_integration', {
+export const ADD_A_CIS_INTEGRATION = i18n.translate('xpack.csp.benchmarks.add_a_cis_integration', {
   defaultMessage: 'Add a CIS integration',
 });
 

--- a/x-pack/plugins/cloud_security_posture/public/pages/benchmarks/translations.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/benchmarks/translations.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+
+export const BENCHMARK_INTEGRATIONS = i18n.translate(
+  'xpack.csp.benchmarks.benchmark_integrations',
+  {
+    defaultMessage: 'Benchmark Integrations',
+  }
+);
+
+export const LOADING_BENCHMARKS = i18n.translate('xpack.csp.benchmarks.loading_benchmarks', {
+  defaultMessage: 'Loading your benchmarks...',
+});
+
+export const ADD_CIS_INTEGRATION = i18n.translate('xpack.csp.benchmarks.add_cis_integration', {
+  defaultMessage: 'Add a CIS integration',
+});
+
+export const TABLE_COLUMN_HEADERS = {
+  INTEGRATION_NAME: i18n.translate('xpack.csp.benchmarks.table_column_headers.integration_name', {
+    defaultMessage: 'Integration Name',
+  }),
+  BENCHMARK: i18n.translate('xpack.csp.benchmarks.table_column_headers.benchmark', {
+    defaultMessage: 'Benchmark',
+  }),
+  ACTIVE_RULES: i18n.translate('xpack.csp.benchmarks.table_column_headers.active_rules', {
+    defaultMessage: 'Active Rules',
+  }),
+  AGENT_POLICY: i18n.translate('xpack.csp.benchmarks.table_column_headers.agent_policy', {
+    defaultMessage: 'Agent Policy',
+  }),
+  NUMBER_OF_AGENTS: i18n.translate('xpack.csp.benchmarks.table_column_headers.number_of_agents', {
+    defaultMessage: 'Number of Agents',
+  }),
+  CREATED_BY: i18n.translate('xpack.csp.benchmarks.table_column_headers.created_by', {
+    defaultMessage: 'Created by',
+  }),
+  CREATED_AT: i18n.translate('xpack.csp.benchmarks.table_column_headers.created_at', {
+    defaultMessage: 'Created at',
+  }),
+};

--- a/x-pack/plugins/cloud_security_posture/public/pages/benchmarks/types.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/benchmarks/types.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-// TODO: This is a mocked interface, waiting for actual BE for the real interface
+// TODO: Use interface from BE https://github.com/elastic/security-team/issues/2942
 export interface CspBenchmarkIntegration {
   integration_name: string;
   benchmark: string;

--- a/x-pack/plugins/cloud_security_posture/public/pages/benchmarks/types.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/benchmarks/types.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+// TODO: This is a mocked interface, waiting for actual BE for the real interface
+export interface CspBenchmarkIntegration {
+  integration_name: string;
+  benchmark: string;
+  rules: {
+    active: number;
+    total: number;
+  };
+  agent_policy: {
+    id: string;
+    name: string;
+    number_of_agents: number;
+  };
+  created_by: string;
+  created_at: Date;
+}

--- a/x-pack/plugins/cloud_security_posture/public/pages/benchmarks/use_csp_benchmark_integrations.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/benchmarks/use_csp_benchmark_integrations.ts
@@ -19,7 +19,7 @@ const FAKE_DATA: CspBenchmarkIntegration[] = [
   createCspBenchmarkIntegrationFixture(),
 ];
 
-// TODO: Use BE once it exists
+// TODO: Use data from BE https://github.com/elastic/security-team/issues/2942
 export const useCspBenchmarkIntegrations = () => {
   return useQuery(QUERY_KEY, () => Promise.resolve(FAKE_DATA));
 };

--- a/x-pack/plugins/cloud_security_posture/public/pages/benchmarks/use_csp_benchmark_integrations.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/benchmarks/use_csp_benchmark_integrations.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useQuery } from 'react-query';
+import { createCspBenchmarkIntegrationFixture } from '../../test/fixtures/csp_benchmark_integration';
+import { CspBenchmarkIntegration } from './types';
+
+const QUERY_KEY = 'csp_benchmark_integrations';
+
+const FAKE_DATA: CspBenchmarkIntegration[] = [
+  createCspBenchmarkIntegrationFixture(),
+  createCspBenchmarkIntegrationFixture(),
+  createCspBenchmarkIntegrationFixture(),
+  createCspBenchmarkIntegrationFixture(),
+  createCspBenchmarkIntegrationFixture(),
+];
+
+// TODO: Use BE once it exists
+export const useCspBenchmarkIntegrations = () => {
+  return useQuery(QUERY_KEY, () => Promise.resolve(FAKE_DATA));
+};

--- a/x-pack/plugins/cloud_security_posture/public/test/fixtures/csp_benchmark_integration.ts
+++ b/x-pack/plugins/cloud_security_posture/public/test/fixtures/csp_benchmark_integration.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/* eslint-disable @typescript-eslint/naming-convention */
+
+import Chance from 'chance';
+import type { CspBenchmarkIntegration } from '../../pages/benchmarks/types';
+
+type CreateCspBenchmarkIntegrationFixtureInput = {
+  chance?: Chance.Chance;
+} & Partial<CspBenchmarkIntegration>;
+
+export const createCspBenchmarkIntegrationFixture = ({
+  chance = new Chance(),
+  integration_name = chance.sentence(),
+  benchmark = chance.sentence(),
+  rules = undefined,
+  agent_policy = {
+    id: chance.guid(),
+    name: chance.sentence(),
+    number_of_agents: chance.integer({ min: 1 }),
+  },
+  created_by = chance.sentence(),
+  created_at = chance.date({ year: 2021 }) as Date,
+}: CreateCspBenchmarkIntegrationFixtureInput = {}): CspBenchmarkIntegration => {
+  let outputRules: CspBenchmarkIntegration['rules'] | undefined = rules;
+  if (!outputRules) {
+    const activeRules = chance.integer({ min: 1 });
+    const totalRules = chance.integer({ min: activeRules });
+    outputRules = {
+      active: activeRules,
+      total: totalRules,
+    };
+  }
+
+  return {
+    integration_name,
+    benchmark,
+    rules: outputRules as CspBenchmarkIntegration['rules'],
+    agent_policy,
+    created_by,
+    created_at,
+  };
+};

--- a/x-pack/plugins/cloud_security_posture/public/test/fixtures/react_query.ts
+++ b/x-pack/plugins/cloud_security_posture/public/test/fixtures/react_query.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { UseQueryResult } from 'react-query/types/react/types';
+
+interface CreateReactQueryResponseInput {
+  status?: UseQueryResult['status'];
+  data?: any;
+  error?: Error;
+}
+
+export const createReactQueryResponse = ({
+  status = 'loading',
+  error = new Error(),
+  data = undefined,
+}: CreateReactQueryResponseInput = {}): UseQueryResult => {
+  if (status === 'success') {
+    return { status, data } as UseQueryResult;
+  }
+
+  if (status === 'error') {
+    return { status, error } as UseQueryResult;
+  }
+
+  return { status } as UseQueryResult;
+};

--- a/x-pack/plugins/cloud_security_posture/public/test/fixtures/react_query.ts
+++ b/x-pack/plugins/cloud_security_posture/public/test/fixtures/react_query.ts
@@ -7,24 +7,24 @@
 
 import type { UseQueryResult } from 'react-query/types/react/types';
 
-interface CreateReactQueryResponseInput {
+interface CreateReactQueryResponseInput<TData = unknown, TError = unknown> {
   status?: UseQueryResult['status'];
-  data?: any;
-  error?: Error;
+  data?: TData;
+  error?: TError;
 }
 
-export const createReactQueryResponse = ({
+export const createReactQueryResponse = <TData = unknown, TError = unknown>({
   status = 'loading',
-  error = new Error(),
+  error = undefined,
   data = undefined,
-}: CreateReactQueryResponseInput = {}): UseQueryResult => {
+}: CreateReactQueryResponseInput<TData, TError> = {}): UseQueryResult<TData, TError> => {
   if (status === 'success') {
-    return { status, data } as UseQueryResult;
+    return { status, data } as UseQueryResult<TData, TError>;
   }
 
   if (status === 'error') {
-    return { status, error } as UseQueryResult;
+    return { status, error } as UseQueryResult<TData, TError>;
   }
 
-  return { status } as UseQueryResult;
+  return { status } as UseQueryResult<TData, TError>;
 };


### PR DESCRIPTION
## Summary

Adding the benchmarks page with the benchmarks table. Solves https://github.com/elastic/security-team/issues/2595
This is using mock data for now, until the server endpoint code is merged.

<img width="1726" alt="Screen Shot 2022-02-01 at 12 37 37" src="https://user-images.githubusercontent.com/94899776/151953744-b18ea7b4-c0cb-4753-9682-d03627013832.png">

