### PR TITLE
add rules page skeleton

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/application/constants.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/application/constants.tsx
@@ -12,4 +12,5 @@ export const pageToComponentMapping: Record<CspPage, RouteProps['component']> = 
   findings: pages.Findings,
   dashboard: pages.ComplianceDashboard,
   benchmarks: pages.Benchmarks,
+  rules: pages.Rules,
 };

--- a/x-pack/plugins/cloud_security_posture/public/common/navigation/constants.ts
+++ b/x-pack/plugins/cloud_security_posture/public/common/navigation/constants.ts
@@ -12,6 +12,7 @@ import type { CspPage, CspNavigationItem } from './types';
 export const allNavigationItems: Record<CspPage, CspNavigationItem> = {
   dashboard: { name: TEXT.DASHBOARD, path: '/dashboard' },
   findings: { name: TEXT.FINDINGS, path: '/findings' },
+  rules: { name: 'Rules', path: '/rules', disabled: true },
   benchmarks: {
     name: TEXT.MY_BENCHMARKS,
     path: '/benchmarks',

--- a/x-pack/plugins/cloud_security_posture/public/common/navigation/types.ts
+++ b/x-pack/plugins/cloud_security_posture/public/common/navigation/types.ts
@@ -10,4 +10,4 @@ export interface CspNavigationItem {
   readonly disabled?: boolean;
 }
 
-export type CspPage = 'dashboard' | 'findings' | 'benchmarks';
+export type CspPage = 'dashboard' | 'findings' | 'benchmarks' | 'rules';

--- a/x-pack/plugins/cloud_security_posture/public/pages/index.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/index.ts
@@ -8,3 +8,4 @@
 export { Findings } from './findings';
 export * from './compliance_dashboard';
 export { Benchmarks } from './benchmarks';
+export { Rules } from './rules';

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/index.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/index.tsx
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React from 'react';
+import type { EuiPageHeaderProps } from '@elastic/eui';
+import { CspPageTemplate } from '../../components/page_template';
+
+// TODO:
+// - get selected integration
+
+const pageHeader: EuiPageHeaderProps = {
+  pageTitle: 'Rules',
+};
+
+export const Rules = () => {
+  return <CspPageTemplate pageHeader={pageHeader} />;
+};


### PR DESCRIPTION
issue:

- https://github.com/elastic/security-team/issues/2766 

this PR introduce a new page under `pages/rules/index.tsx` 

currently empty, will be populated by another PR

**TODO**:
- relate to integration in terms of routing and information to display in page template 

**NOTE**:
to be merged after:
- #115 
- #119 
