### PR TITLE
add rules table container

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/common/navigation/constants.ts
+++ b/x-pack/plugins/cloud_security_posture/public/common/navigation/constants.ts
@@ -12,7 +12,7 @@ import type { CspPage, CspNavigationItem } from './types';
 export const allNavigationItems: Record<CspPage, CspNavigationItem> = {
   dashboard: { name: TEXT.DASHBOARD, path: '/dashboard' },
   findings: { name: TEXT.FINDINGS, path: '/findings' },
-  rules: { name: 'Rules', path: '/rules', disabled: true },
+  rules: { name: 'Rules', path: '/rules', disabled: false },
   benchmarks: {
     name: TEXT.MY_BENCHMARKS,
     path: '/benchmarks',

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/index.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/index.tsx
@@ -7,6 +7,7 @@
 import React from 'react';
 import type { EuiPageHeaderProps } from '@elastic/eui';
 import { CspPageTemplate } from '../../components/page_template';
+import { RulesContainer } from './rules_container';
 
 // TODO:
 // - get selected integration
@@ -16,5 +17,9 @@ const pageHeader: EuiPageHeaderProps = {
 };
 
 export const Rules = () => {
-  return <CspPageTemplate pageHeader={pageHeader} />;
+  return (
+    <CspPageTemplate pageHeader={pageHeader}>
+      <RulesContainer />
+    </CspPageTemplate>
+  );
 };

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_bottom_bar.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_bottom_bar.tsx
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React from 'react';
+import { EuiFlexGroup, EuiFlexItem, EuiBottomBar, EuiButton } from '@elastic/eui';
+import * as TEST_SUBJECTS from './test_subjects';
+import * as TEXT from './translations';
+
+interface RulesBottomBarProps {
+  onSave(): void;
+  onCancel(): void;
+  isLoading: boolean;
+}
+
+export const RulesBottomBar = ({ onSave, onCancel, isLoading }: RulesBottomBarProps) => (
+  <EuiBottomBar>
+    <EuiFlexGroup justifyContent="flexEnd">
+      <EuiFlexItem grow={false}>
+        <EuiButton size="m" iconType="cross" isLoading={isLoading} onClick={onCancel} color="ghost">
+          {TEXT.CANCEL}
+        </EuiButton>
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiButton
+          size="m"
+          iconType="save"
+          isLoading={isLoading}
+          onClick={onSave}
+          fill
+          data-test-subj={TEST_SUBJECTS.CSP_RULES_SAVE_BUTTON}
+        >
+          {TEXT.SAVE}
+        </EuiButton>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  </EuiBottomBar>
+);

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_container.test.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_container.test.tsx
@@ -1,0 +1,306 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { RulesContainer, type RuleSavedObject } from './rules_container';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { QueryClient } from 'react-query';
+import { useFindCspRules, useBulkUpdateCspRules } from './use_csp_rules';
+import * as TEST_SUBJECTS from './test_subjects';
+import { Chance } from 'chance';
+import { TestProvider } from '../../test/test_provider';
+
+const chance = new Chance();
+
+jest.mock('./use_csp_rules', () => ({
+  useFindCspRules: jest.fn(),
+  useBulkUpdateCspRules: jest.fn(),
+}));
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: { retry: false },
+  },
+});
+
+const getWrapper =
+  (): React.FC =>
+  ({ children }) =>
+    <TestProvider>{children}</TestProvider>;
+
+const getFakeRule = ({ id = chance.guid(), enabled }: { id?: string; enabled: boolean }) =>
+  ({
+    id,
+    updated_at: chance.date().toISOString(),
+    attributes: {
+      id,
+      name: chance.word(),
+      enabled,
+    },
+  } as RuleSavedObject);
+
+const useFindCspRulesMock = (value: any) => (useFindCspRules as jest.Mock).mockReturnValue(value);
+
+describe('<RulesContainer />', () => {
+  beforeEach(() => {
+    queryClient.clear();
+    jest.clearAllMocks();
+    (useBulkUpdateCspRules as jest.Mock).mockReturnValue({
+      status: 'idle',
+      mutate: jest.fn(),
+    });
+  });
+
+  it('displays rules with their initial state', async () => {
+    const Wrapper = getWrapper();
+    const rule1 = getFakeRule({ enabled: true });
+
+    useFindCspRulesMock({
+      status: 'success',
+      data: {
+        total: 1,
+        savedObjects: [rule1],
+      },
+    });
+
+    render(
+      <Wrapper>
+        <RulesContainer />
+      </Wrapper>
+    );
+
+    expect(await screen.getByTestId(TEST_SUBJECTS.CSP_RULES_CONTAINER)).toBeInTheDocument();
+    expect(await screen.getByText(rule1.attributes.name)).toBeInTheDocument();
+    expect(
+      screen
+        .getByTestId(TEST_SUBJECTS.getCspRulesTableItemSwitchTestId(rule1.id))
+        .getAttribute('aria-checked')
+    ).toEqual('true');
+  });
+
+  it('toggles rules locally', () => {
+    const Wrapper = getWrapper();
+    const rule1 = getFakeRule({ enabled: false });
+    const rule2 = getFakeRule({ enabled: true });
+
+    useFindCspRulesMock({
+      status: 'success',
+      data: {
+        total: 2,
+        savedObjects: [rule1, rule2],
+      },
+    });
+
+    render(
+      <Wrapper>
+        <RulesContainer />
+      </Wrapper>
+    );
+
+    const switchId1 = TEST_SUBJECTS.getCspRulesTableItemSwitchTestId(rule1.id);
+    const switchId2 = TEST_SUBJECTS.getCspRulesTableItemSwitchTestId(rule2.id);
+
+    fireEvent.click(screen.getByTestId(switchId1));
+    fireEvent.click(screen.getByTestId(switchId2));
+
+    expect(screen.getByTestId(switchId1).getAttribute('aria-checked')).toEqual(
+      (!rule1.attributes.enabled).toString()
+    );
+    expect(screen.getByTestId(switchId2).getAttribute('aria-checked')).toEqual(
+      (!rule2.attributes.enabled).toString()
+    );
+  });
+
+  it('bulk toggles rules locally', () => {
+    const Wrapper = getWrapper();
+    const rule1 = getFakeRule({ enabled: true });
+    const rule2 = getFakeRule({ enabled: true });
+    const rule3 = getFakeRule({ enabled: false });
+
+    useFindCspRulesMock({
+      status: 'success',
+      data: {
+        total: 3,
+        savedObjects: [rule1, rule2, rule3],
+      },
+    });
+
+    render(
+      <Wrapper>
+        <RulesContainer />
+      </Wrapper>
+    );
+
+    const switchId1 = TEST_SUBJECTS.getCspRulesTableItemSwitchTestId(rule1.id);
+    const switchId2 = TEST_SUBJECTS.getCspRulesTableItemSwitchTestId(rule2.id);
+    const switchId3 = TEST_SUBJECTS.getCspRulesTableItemSwitchTestId(rule3.id);
+
+    fireEvent.click(screen.getByTestId('checkboxSelectAll'));
+    fireEvent.click(screen.getByTestId(TEST_SUBJECTS.CSP_RULES_TABLE_BULK_MENU_BUTTON));
+    fireEvent.click(screen.getByTestId(TEST_SUBJECTS.CSP_RULES_TABLE_BULK_DISABLE_BUTTON));
+
+    expect(screen.getByTestId(switchId1).getAttribute('aria-checked')).toEqual(
+      (!rule1.attributes.enabled).toString()
+    );
+    expect(screen.getByTestId(switchId2).getAttribute('aria-checked')).toEqual(
+      (!rule2.attributes.enabled).toString()
+    );
+    expect(screen.getByTestId(switchId3).getAttribute('aria-checked')).toEqual(
+      rule3.attributes.enabled.toString()
+    );
+  });
+
+  it('updates rules with local changes done by non-bulk toggles', () => {
+    const Wrapper = getWrapper();
+    const rule1 = getFakeRule({ enabled: false });
+    const rule2 = getFakeRule({ enabled: true });
+    const rule3 = getFakeRule({ enabled: true });
+
+    useFindCspRulesMock({
+      status: 'success',
+      data: {
+        total: 3,
+        savedObjects: [rule1, rule2, rule3],
+      },
+    });
+
+    render(
+      <Wrapper>
+        <RulesContainer />
+      </Wrapper>
+    );
+    const { mutate } = useBulkUpdateCspRules();
+
+    const switchId1 = TEST_SUBJECTS.getCspRulesTableItemSwitchTestId(rule1.id);
+    const switchId2 = TEST_SUBJECTS.getCspRulesTableItemSwitchTestId(rule2.id);
+    const switchId3 = TEST_SUBJECTS.getCspRulesTableItemSwitchTestId(rule3.id);
+
+    fireEvent.click(screen.getByTestId(switchId1));
+    fireEvent.click(screen.getByTestId(switchId2));
+    fireEvent.click(screen.getByTestId(switchId3)); // adds
+    fireEvent.click(screen.getByTestId(switchId3)); // removes
+    fireEvent.click(screen.getByTestId(TEST_SUBJECTS.CSP_RULES_SAVE_BUTTON));
+
+    expect(mutate).toHaveBeenCalledTimes(1);
+    expect(mutate).toHaveBeenCalledWith([
+      { ...rule1.attributes, enabled: !rule1.attributes.enabled },
+      { ...rule2.attributes, enabled: !rule2.attributes.enabled },
+    ]);
+  });
+
+  it('updates rules with local changes done by bulk toggles', () => {
+    const Wrapper = getWrapper();
+    const rule1 = getFakeRule({ enabled: false });
+    const rule2 = getFakeRule({ enabled: true });
+    const rule3 = getFakeRule({ enabled: true });
+
+    useFindCspRulesMock({
+      status: 'success',
+      data: {
+        total: 3,
+        savedObjects: [rule1, rule2, rule3],
+      },
+    });
+
+    render(
+      <Wrapper>
+        <RulesContainer />
+      </Wrapper>
+    );
+    const { mutate } = useBulkUpdateCspRules();
+
+    fireEvent.click(screen.getByTestId('checkboxSelectAll'));
+    fireEvent.click(screen.getByTestId(TEST_SUBJECTS.CSP_RULES_TABLE_BULK_MENU_BUTTON));
+    fireEvent.click(screen.getByTestId(TEST_SUBJECTS.CSP_RULES_TABLE_BULK_ENABLE_BUTTON)); // This should only change rule1
+    fireEvent.click(screen.getByTestId(TEST_SUBJECTS.CSP_RULES_SAVE_BUTTON));
+
+    expect(mutate).toHaveBeenCalledTimes(1);
+    expect(mutate).toHaveBeenCalledWith([
+      { ...rule1.attributes, enabled: !rule1.attributes.enabled },
+    ]);
+  });
+
+  it('only changes selected rules in bulk operations', () => {
+    const Wrapper = getWrapper();
+    const rule1 = getFakeRule({ enabled: false });
+    const rule2 = getFakeRule({ enabled: true });
+    const rule3 = getFakeRule({ enabled: false });
+    const rule4 = getFakeRule({ enabled: false });
+    const rule5 = getFakeRule({ enabled: true });
+
+    useFindCspRulesMock({
+      status: 'success',
+      data: {
+        total: 4,
+        savedObjects: [rule1, rule2, rule3, rule4, rule5],
+      },
+    });
+
+    render(
+      <Wrapper>
+        <RulesContainer />
+      </Wrapper>
+    );
+    const { mutate } = useBulkUpdateCspRules();
+
+    fireEvent.click(screen.getByTestId(`checkboxSelectRow-${rule1.id}`)); // changes
+    fireEvent.click(screen.getByTestId(`checkboxSelectRow-${rule2.id}`)); // doesn't change
+    fireEvent.click(screen.getByTestId(`checkboxSelectRow-${rule4.id}`)); // changes
+    fireEvent.click(screen.getByTestId(TEST_SUBJECTS.CSP_RULES_TABLE_BULK_MENU_BUTTON));
+    fireEvent.click(screen.getByTestId(TEST_SUBJECTS.CSP_RULES_TABLE_BULK_ENABLE_BUTTON));
+    fireEvent.click(screen.getByTestId(TEST_SUBJECTS.getCspRulesTableItemSwitchTestId(rule5.id))); // changes
+    fireEvent.click(screen.getByTestId(TEST_SUBJECTS.CSP_RULES_SAVE_BUTTON));
+
+    expect(mutate).toHaveBeenCalledTimes(1);
+    expect(mutate).toHaveBeenCalledWith([
+      { ...rule1.attributes, enabled: !rule1.attributes.enabled },
+      { ...rule4.attributes, enabled: !rule4.attributes.enabled },
+      { ...rule5.attributes, enabled: !rule5.attributes.enabled },
+    ]);
+  });
+
+  it('updates rules with changes of both bulk/non-bulk toggles', () => {
+    const Wrapper = getWrapper();
+    const rule1 = getFakeRule({ enabled: false });
+    const rule2 = getFakeRule({ enabled: true });
+    const rule3 = getFakeRule({ enabled: false });
+    const rule4 = getFakeRule({ enabled: false });
+    const rule5 = getFakeRule({ enabled: true });
+
+    useFindCspRulesMock({
+      status: 'success',
+      data: {
+        total: 4,
+        savedObjects: [rule1, rule2, rule3, rule4, rule5],
+      },
+    });
+
+    render(
+      <Wrapper>
+        <RulesContainer />
+      </Wrapper>
+    );
+
+    const { mutate } = useBulkUpdateCspRules();
+
+    fireEvent.click(screen.getByTestId(`checkboxSelectRow-${rule1.id}`)); // changes rule1
+    fireEvent.click(screen.getByTestId(`checkboxSelectRow-${rule2.id}`)); // doesn't change
+    fireEvent.click(screen.getByTestId(`checkboxSelectRow-${rule4.id}`)); // changes rule4
+    fireEvent.click(screen.getByTestId(TEST_SUBJECTS.CSP_RULES_TABLE_BULK_MENU_BUTTON));
+    fireEvent.click(screen.getByTestId(TEST_SUBJECTS.CSP_RULES_TABLE_BULK_DISABLE_BUTTON)); // changes rule2
+    fireEvent.click(screen.getByTestId(TEST_SUBJECTS.CSP_RULES_TABLE_BULK_ENABLE_BUTTON)); // reverts rule2
+    fireEvent.click(screen.getByTestId(TEST_SUBJECTS.getCspRulesTableItemSwitchTestId(rule5.id))); // changes rule5
+    fireEvent.click(screen.getByTestId(TEST_SUBJECTS.CSP_RULES_SAVE_BUTTON));
+
+    expect(mutate).toHaveBeenCalledTimes(1);
+    expect(mutate).toHaveBeenCalledWith([
+      { ...rule1.attributes, enabled: !rule1.attributes.enabled },
+      { ...rule4.attributes, enabled: !rule4.attributes.enabled },
+      { ...rule5.attributes, enabled: !rule5.attributes.enabled },
+    ]);
+  });
+});

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_container.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_container.tsx
@@ -23,7 +23,12 @@ type SimpleRulesQueryResult = DistributivePick<RulesQueryResult, 'data' | 'error
 
 /** Rules with local changes */
 type LocalRulesResult =
-  | Exclude<SimpleRulesQueryResult, { status: 'success' }>
+  | Exclude<SimpleRulesQueryResult, { status: 'success' | 'error' }>
+  | {
+      status: 'error';
+      error: string;
+      data: undefined;
+    }
   | {
       status: 'success';
       error: null;
@@ -73,6 +78,7 @@ const getLocalRulesResult = (
     case 'error':
       return {
         ...result,
+        data: undefined,
         error: extractErrorMessage(result.error),
       };
     default:

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_container.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_container.tsx
@@ -1,0 +1,173 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React, { useEffect, useState, useMemo, useCallback } from 'react';
+import { EuiPanel } from '@elastic/eui';
+import { SavedObject } from 'src/core/public';
+import { extractErrorMessage } from '../../../common/utils/helpers';
+import { RulesTable } from './rules_table';
+import { RulesBottomBar } from './rules_bottom_bar';
+import { RulesTableHeader } from './rules_table_header';
+import type { CspRuleSchema } from '../../../common/schemas/csp_rule';
+import { useFindCspRules, useBulkUpdateCspRules, type UseCspRulesOptions } from './use_csp_rules';
+import * as TEST_SUBJECTS from './test_subjects';
+
+export type RuleSavedObject = SavedObject<CspRuleSchema>; // SimpleSavedObject
+
+type RulesQuery = Required<Omit<UseCspRulesOptions, 'searchFields'>>;
+type RulesQueryResult = ReturnType<typeof useFindCspRules>;
+type SimpleRulesQueryResult = DistributivePick<RulesQueryResult, 'data' | 'error' | 'status'>;
+
+/** Rules with local changes */
+type LocalRulesResult =
+  | Exclude<SimpleRulesQueryResult, { status: 'success' }>
+  | {
+      status: 'success';
+      error: null;
+      data: readonly RuleSavedObject[];
+      total: number;
+    };
+
+export type RulesState = LocalRulesResult & RulesQuery;
+
+const getSimpleQueryString = (searchValue?: string): string =>
+  searchValue ? `${searchValue}*` : '';
+
+const getChangedRules = (
+  baseRules: ReadonlyMap<string, RuleSavedObject>,
+  currentChangedRules: ReadonlyMap<string, RuleSavedObject>,
+  rulesToChange: readonly RuleSavedObject[]
+): Map<string, RuleSavedObject> => {
+  const changedRules = new Map(currentChangedRules);
+
+  rulesToChange.forEach((ruleToChange) => {
+    const baseRule = baseRules.get(ruleToChange.id);
+    const changedRule = changedRules.get(ruleToChange.id);
+
+    if (!baseRule) throw new Error('expected base rule to exists');
+
+    const baseRuleChanged = baseRule.attributes.enabled !== ruleToChange.attributes.enabled;
+
+    if (!changedRule && baseRuleChanged) changedRules.set(ruleToChange.id, ruleToChange);
+
+    if (changedRule && !baseRuleChanged) changedRules.delete(ruleToChange.id);
+  });
+
+  return changedRules;
+};
+
+const getLocalRulesResult = (
+  result: SimpleRulesQueryResult,
+  localData: readonly RuleSavedObject[]
+): LocalRulesResult => {
+  switch (result.status) {
+    case 'success':
+      return {
+        ...result,
+        data: localData,
+        total: result.data.total,
+      };
+    case 'error':
+      return {
+        ...result,
+        error: extractErrorMessage(result.error),
+      };
+    default:
+      return result;
+  }
+};
+
+export const RulesContainer = () => {
+  const [changedRules, setChangedRules] = useState<Map<string, RuleSavedObject>>(new Map());
+  const [selectedRules, setSelectedRules] = useState<RuleSavedObject[]>([]);
+  const [rulesQuery, setRulesQuery] = useState<RulesQuery>({ page: 1, perPage: 5, search: '' });
+
+  const { data, status, error, refetch } = useFindCspRules({
+    ...rulesQuery,
+    search: getSimpleQueryString(rulesQuery.search),
+    searchFields: ['name'],
+  });
+
+  const { mutate: bulkUpdate, isLoading: isUpdating } = useBulkUpdateCspRules();
+
+  const baseData: { rules: RuleSavedObject[]; rulesMap: Map<string, RuleSavedObject> } =
+    useMemo(() => {
+      const rules = data?.savedObjects || [];
+      return { rules, rulesMap: new Map(rules.map((rule) => [rule.id, rule])) };
+    }, [data]);
+
+  /**
+   * TODO(TS@4.6): remove casting
+   * @see https://github.com/microsoft/TypeScript/pull/46266
+   */
+  const localRulesResult = useMemo(
+    () =>
+      getLocalRulesResult(
+        { data, error, status } as SimpleRulesQueryResult,
+        baseData.rules.map((rule) => changedRules.get(rule.attributes.id) || rule)
+      ),
+    [baseData, changedRules, status, data, error]
+  );
+
+  const hasChanges = !!changedRules.size;
+
+  const toggleRules = (rules: RuleSavedObject[], enabled: boolean) =>
+    setChangedRules(
+      getChangedRules(
+        baseData.rulesMap,
+        changedRules,
+        rules.map((rule) => ({
+          ...rule,
+          attributes: { ...rule.attributes, enabled },
+        }))
+      )
+    );
+
+  const bulkToggleRules = (enabled: boolean) =>
+    toggleRules(
+      selectedRules.map((rule) => baseData.rulesMap.get(rule.id)!),
+      enabled
+    );
+
+  const toggleRule = (rule: RuleSavedObject) => toggleRules([rule], !rule.attributes.enabled);
+
+  const bulkUpdateRules = () => bulkUpdate([...changedRules].map(([, rule]) => rule.attributes));
+
+  const discardChanges = useCallback(() => setChangedRules(new Map()), []);
+
+  useEffect(discardChanges, [baseData, discardChanges]);
+
+  return (
+    <div data-test-subj={TEST_SUBJECTS.CSP_RULES_CONTAINER}>
+      <EuiPanel hasBorder hasShadow={false}>
+        <RulesTableHeader
+          search={(value) => setRulesQuery((currentQuery) => ({ ...currentQuery, search: value }))}
+          refresh={refetch}
+          bulkEnable={() => bulkToggleRules(true)}
+          bulkDisable={() => bulkToggleRules(false)}
+          selectedRulesCount={selectedRules.length}
+          searchValue={rulesQuery.search}
+          totalRulesCount={localRulesResult.status === 'success' ? localRulesResult.total : 0}
+          isSearching={localRulesResult.status === 'loading'}
+        />
+        <RulesTable
+          {...localRulesResult}
+          {...rulesQuery}
+          toggleRule={toggleRule}
+          setSelectedRules={setSelectedRules}
+          setPagination={(paginationQuery) =>
+            setRulesQuery((currentQuery) => ({ ...currentQuery, ...paginationQuery }))
+          }
+        />
+      </EuiPanel>
+      {!!hasChanges && (
+        <RulesBottomBar onSave={bulkUpdateRules} onCancel={discardChanges} isLoading={isUpdating} />
+      )}
+    </div>
+  );
+};
+
+type DistributivePick<T, K extends keyof T> = T extends unknown ? Pick<T, K> : never;

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table.tsx
@@ -15,7 +15,6 @@ import {
   EuiBasicTableProps,
 } from '@elastic/eui';
 // import moment from 'moment';
-import { extractErrorMessage } from '../../../common/utils/helpers';
 import type { RulesState, RuleSavedObject } from './rules_container';
 import * as TEST_SUBJECTS from './test_subjects';
 import * as TEXT from './translations';
@@ -68,7 +67,7 @@ export const RulesTable = ({
     <EuiBasicTable
       data-test-subj={TEST_SUBJECTS.CSP_RULES_TABLE}
       loading={props.status === 'loading'}
-      error={props.error ? extractErrorMessage(props.error) : undefined}
+      error={props.error || undefined}
       items={items}
       columns={columns}
       pagination={euiPagination}

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table.tsx
@@ -1,0 +1,137 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React, { useMemo } from 'react';
+import {
+  Criteria,
+  EuiLink,
+  EuiSwitch,
+  EuiTableFieldDataColumnType,
+  EuiEmptyPrompt,
+  EuiBasicTable,
+  EuiBasicTableProps,
+} from '@elastic/eui';
+import moment from 'moment';
+import { extractErrorMessage } from '../../../common/utils/helpers';
+import type { RulesState, RuleSavedObject } from './rules_container';
+import * as TEST_SUBJECTS from './test_subjects';
+import * as TEXT from './translations';
+
+type RulesTableProps = RulesState & {
+  toggleRule(rule: RuleSavedObject): void;
+  setSelectedRules(rules: RuleSavedObject[]): void;
+  setPagination(pagination: Pick<RulesState, 'perPage' | 'page'>): void;
+};
+
+export const RulesTable = ({
+  toggleRule,
+  setSelectedRules,
+  setPagination,
+  perPage,
+  page,
+  ...props
+}: RulesTableProps) => {
+  const columns = useMemo(() => getColumns({ toggleRule }), [toggleRule]);
+
+  const items = useMemo(
+    () => (props.status === 'success' ? props.data?.slice() || [] : []),
+    [props.data, props.status]
+  );
+
+  const euiPagination: EuiBasicTableProps<RuleSavedObject>['pagination'] = {
+    pageIndex: Math.max(page - 1, 0),
+    pageSize: perPage,
+    totalItemCount: props.status === 'success' ? props.total : 0,
+    pageSizeOptions: [1, 5, 10, 25],
+    hidePerPageOptions: false,
+  };
+
+  const selection: EuiBasicTableProps<RuleSavedObject>['selection'] = {
+    selectable: () => true,
+    onSelectionChange: setSelectedRules,
+  };
+
+  const onTableChange = ({ page: _page }: Criteria<RuleSavedObject>) => {
+    if (!_page) return;
+    setPagination({ page: _page.index + 1, perPage: _page.size });
+  };
+
+  // Show "zero state"
+  if (props.status === 'success' && !props.data)
+    // TODO: use our own logo
+    return <EuiEmptyPrompt iconType="logoKibana" title={<h2>{TEXT.MISSING_RULES}</h2>} />;
+
+  return (
+    <EuiBasicTable
+      data-test-subj={TEST_SUBJECTS.CSP_RULES_TABLE}
+      loading={props.status === 'loading'}
+      error={props.error ? extractErrorMessage(props.error) : undefined}
+      items={items}
+      columns={columns}
+      pagination={euiPagination}
+      onChange={onTableChange}
+      isSelectable={true}
+      selection={selection}
+      itemId={(v) => v.id}
+    />
+  );
+};
+
+const ruleNameRenderer = (name: string) => (
+  <EuiLink className="eui-textTruncate" title={name}>
+    {name}
+  </EuiLink>
+);
+
+const timestampRenderer = (timestamp: string) =>
+  moment.duration(moment().diff(timestamp)).humanize();
+
+interface GetColumnProps {
+  toggleRule: (rule: RuleSavedObject) => void;
+}
+
+const createRuleEnabledSwitchRenderer =
+  ({ toggleRule }: GetColumnProps) =>
+  (value: any, rule: RuleSavedObject) =>
+    (
+      <EuiSwitch
+        label=""
+        checked={value}
+        onChange={() => toggleRule(rule)}
+        data-test-subj={TEST_SUBJECTS.getCspRulesTableItemSwitchTestId(rule.attributes.id)}
+      />
+    );
+
+const getColumns = ({
+  toggleRule,
+}: GetColumnProps): Array<EuiTableFieldDataColumnType<RuleSavedObject>> => [
+  {
+    field: 'attributes.name',
+    name: TEXT.RULE_NAME,
+    width: '60%',
+    truncateText: true,
+    render: ruleNameRenderer,
+  },
+  {
+    field: 'section', // TODO: what field is this?
+    name: TEXT.SECTION,
+    width: '15%',
+  },
+  {
+    // TODO: get timestamp value
+    // add SavedObject["updated_at"] to SimpleSavedObject?
+    field: 'updated_at',
+    name: TEXT.UPDATED_AT,
+    width: '15%',
+    // render: timestampRenderer,
+  },
+  {
+    field: 'attributes.enabled',
+    name: TEXT.ENABLED,
+    render: createRuleEnabledSwitchRenderer({ toggleRule }),
+    width: '10%',
+  },
+];

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table.tsx
@@ -14,7 +14,7 @@ import {
   EuiBasicTable,
   EuiBasicTableProps,
 } from '@elastic/eui';
-import moment from 'moment';
+// import moment from 'moment';
 import { extractErrorMessage } from '../../../common/utils/helpers';
 import type { RulesState, RuleSavedObject } from './rules_container';
 import * as TEST_SUBJECTS from './test_subjects';
@@ -86,8 +86,8 @@ const ruleNameRenderer = (name: string) => (
   </EuiLink>
 );
 
-const timestampRenderer = (timestamp: string) =>
-  moment.duration(moment().diff(timestamp)).humanize();
+// const timestampRenderer = (timestamp: string) =>
+//   moment.duration(moment().diff(timestamp)).humanize();
 
 interface GetColumnProps {
   toggleRule: (rule: RuleSavedObject) => void;

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table_header.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table_header.tsx
@@ -1,0 +1,138 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React, { useState } from 'react';
+import {
+  EuiContextMenuPanel,
+  EuiContextMenuItem,
+  EuiContextMenuItemProps,
+  EuiPopover,
+  EuiSpacer,
+  EuiFieldSearch,
+  useGeneratedHtmlId,
+  EuiButtonEmpty,
+  EuiFlexGroup,
+  EuiFlexItem,
+} from '@elastic/eui';
+import * as TEST_SUBJECTS from './test_subjects';
+import * as TEXT from './translations';
+
+interface RulesBulkActionsMenuProps {
+  items: ReadonlyArray<EuiContextMenuItemProps & { text: string }>;
+}
+
+interface RuelsTableToolbarProps {
+  search(value: string): void;
+  refresh(): void;
+  bulkEnable(): void;
+  bulkDisable(): void;
+  selectedRulesCount: number;
+  searchValue: string;
+  isSearching: boolean;
+}
+
+export const RulesTableHeader = ({
+  search,
+  refresh,
+  bulkEnable,
+  bulkDisable,
+  selectedRulesCount,
+  searchValue,
+  isSearching,
+}: RuelsTableToolbarProps) => (
+  <div>
+    <EuiFlexGroup alignItems="center" justifyContent="spaceBetween">
+      <EuiFlexItem grow={true}>
+        <span>
+          Selected <strong>{selectedRulesCount}</strong> rules
+        </span>
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <RulesBulkActionsMenu
+          items={[
+            {
+              icon: 'copy', // TODO: icon
+              text: TEXT.ENABLE, // TODO: i18n
+              'data-test-subj': TEST_SUBJECTS.CSP_RULES_TABLE_BULK_ENABLE_BUTTON,
+              onClick: bulkEnable,
+            },
+            {
+              icon: 'copy', // TODO: icon
+              text: TEXT.DISABLE, // TODO: i18n
+              'data-test-subj': TEST_SUBJECTS.CSP_RULES_TABLE_BULK_DISABLE_BUTTON,
+              onClick: bulkDisable,
+            },
+          ]}
+        />
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiButtonEmpty
+          onClick={refresh}
+          iconType={'refresh'}
+          data-test-subj={TEST_SUBJECTS.CSP_RULES_TABLE_REFRESH_BUTTON}
+        >
+          {TEXT.REFRESH}
+        </EuiButtonEmpty>
+      </EuiFlexItem>
+      <EuiFlexItem grow={true}>
+        <EuiFieldSearch
+          isLoading={isSearching}
+          placeholder={TEXT.SEARCH}
+          value={searchValue}
+          onChange={(e) => search(e.target.value)}
+        />
+      </EuiFlexItem>
+    </EuiFlexGroup>
+    <EuiSpacer />
+  </div>
+);
+
+const RulesBulkActionsMenu = ({ items }: RulesBulkActionsMenuProps) => {
+  const [isPopoverOpen, setPopover] = useState(false);
+  const smallContextMenuPopoverId = useGeneratedHtmlId({
+    prefix: 'smallContextMenuPopover',
+  });
+
+  const onButtonClick = () => setPopover(!isPopoverOpen);
+
+  const closePopover = () => setPopover(false);
+
+  const data = items.map((item) => (
+    <EuiContextMenuItem
+      {...item}
+      key={item.text}
+      children={item.text}
+      onClick={(e) => {
+        closePopover();
+        item.onClick?.(e);
+      }}
+    />
+  ));
+
+  // TODO: i18n
+  const button = (
+    <EuiButtonEmpty
+      iconType={'arrowDown'}
+      onClick={onButtonClick}
+      data-test-subj={TEST_SUBJECTS.CSP_RULES_TABLE_BULK_MENU_BUTTON}
+    >
+      {TEXT.BULK_ACTIONS}
+    </EuiButtonEmpty>
+  );
+
+  return (
+    <EuiPopover
+      id={smallContextMenuPopoverId}
+      button={button}
+      isOpen={isPopoverOpen}
+      closePopover={closePopover}
+      panelPaddingSize="none"
+      anchorPosition="downLeft"
+    >
+      <EuiContextMenuPanel size="s" items={data} />
+    </EuiPopover>
+  );
+};

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table_header.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table_header.tsx
@@ -17,6 +17,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
 } from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n-react';
 import * as TEST_SUBJECTS from './test_subjects';
 import * as TEXT from './translations';
 
@@ -24,11 +25,12 @@ interface RulesBulkActionsMenuProps {
   items: ReadonlyArray<EuiContextMenuItemProps & { text: string }>;
 }
 
-interface RuelsTableToolbarProps {
+interface RulesTableToolbarProps {
   search(value: string): void;
   refresh(): void;
   bulkEnable(): void;
   bulkDisable(): void;
+  totalRulesCount: number;
   selectedRulesCount: number;
   searchValue: string;
   isSearching: boolean;
@@ -39,29 +41,45 @@ export const RulesTableHeader = ({
   refresh,
   bulkEnable,
   bulkDisable,
+  totalRulesCount,
   selectedRulesCount,
   searchValue,
   isSearching,
-}: RuelsTableToolbarProps) => (
+}: RulesTableToolbarProps) => (
   <div>
     <EuiFlexGroup alignItems="center" justifyContent="spaceBetween">
-      <EuiFlexItem grow={true}>
-        <span>
-          Selected <strong>{selectedRulesCount}</strong> rules
-        </span>
+      <EuiFlexItem
+        grow={false}
+        style={{ flexDirection: 'row', fontVariantNumeric: 'tabular-nums' }}
+      >
+        <FormattedMessage
+          id="xpack.csp.rules.total_rules_count"
+          defaultMessage="Showing {totalRulesCount} rules"
+          values={{
+            totalRulesCount: <b>&nbsp;{totalRulesCount}&nbsp;</b>,
+          }}
+        />
+        <span>&nbsp;&nbsp;|&nbsp;&nbsp;</span>
+        <FormattedMessage
+          id="xpack.csp.rules.selected_rules_count"
+          defaultMessage="Selected {selectedRulesCount} rules"
+          values={{
+            selectedRulesCount: <b>&nbsp;{selectedRulesCount}&nbsp;</b>,
+          }}
+        />
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
         <RulesBulkActionsMenu
           items={[
             {
               icon: 'copy', // TODO: icon
-              text: TEXT.ENABLE, // TODO: i18n
+              text: TEXT.ENABLE,
               'data-test-subj': TEST_SUBJECTS.CSP_RULES_TABLE_BULK_ENABLE_BUTTON,
               onClick: bulkEnable,
             },
             {
               icon: 'copy', // TODO: icon
-              text: TEXT.DISABLE, // TODO: i18n
+              text: TEXT.DISABLE,
               'data-test-subj': TEST_SUBJECTS.CSP_RULES_TABLE_BULK_DISABLE_BUTTON,
               onClick: bulkDisable,
             },
@@ -77,7 +95,7 @@ export const RulesTableHeader = ({
           {TEXT.REFRESH}
         </EuiButtonEmpty>
       </EuiFlexItem>
-      <EuiFlexItem grow={true}>
+      <EuiFlexItem grow={true} style={{ alignItems: 'flex-end' }}>
         <EuiFieldSearch
           isLoading={isSearching}
           placeholder={TEXT.SEARCH}
@@ -112,7 +130,6 @@ const RulesBulkActionsMenu = ({ items }: RulesBulkActionsMenuProps) => {
     />
   ));
 
-  // TODO: i18n
   const button = (
     <EuiButtonEmpty
       iconType={'arrowDown'}

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/test_subjects.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/test_subjects.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const CSP_RULES_CONTAINER = 'csp_rules_container';
+export const CSP_RULES_TABLE_ITEM_SWITCH = 'csp_rules_table_item_switch';
+export const CSP_RULES_SAVE_BUTTON = 'csp_rules_table_save_button';
+export const CSP_RULES_TABLE = 'csp_rules_table';
+export const CSP_RULES_TABLE_BULK_MENU_BUTTON = 'csp_rules_table_bulk_menu_button';
+export const CSP_RULES_TABLE_BULK_ENABLE_BUTTON = 'csp_rules_table_bulk_enable_button';
+export const CSP_RULES_TABLE_BULK_DISABLE_BUTTON = 'csp_rules_table_bulk_disable_button';
+export const CSP_RULES_TABLE_REFRESH_BUTTON = 'csp_rules_table_refresh_button';
+
+export const getCspRulesTableItemSwitchTestId = (id: string) =>
+  `${CSP_RULES_TABLE_ITEM_SWITCH}_${id}`;

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/translations.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/translations.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+
+export const SAVE = i18n.translate('xpack.csp.save', {
+  defaultMessage: 'Save',
+});
+
+export const CANCEL = i18n.translate('xpack.csp.cancel', {
+  defaultMessage: 'Cancel',
+});
+
+export const UNKNOWN_ERROR = i18n.translate('xpack.csp.unknown_erro', {
+  defaultMessage: 'Unknown Error',
+});
+
+export const ENABLE = i18n.translate('xpack.csp.enable', {
+  defaultMessage: 'Enable',
+});
+
+export const DISABLE = i18n.translate('xpack.csp.disable', {
+  defaultMessage: 'Disable',
+});
+
+export const REFRESH = i18n.translate('xpack.csp.refresh', {
+  defaultMessage: 'Refresh',
+});
+
+export const SEARCH = i18n.translate('xpack.csp.search', {
+  defaultMessage: 'Search',
+});
+
+export const BULK_ACTIONS = i18n.translate('xpack.csp.bulk_actions', {
+  defaultMessage: 'Bulk Actions',
+});
+
+export const RULE_NAME = i18n.translate('xpack.csp.rule_name', {
+  defaultMessage: 'Rule Name',
+});
+
+export const SECTION = i18n.translate('xpack.csp.section', {
+  defaultMessage: 'Section',
+});
+
+export const UPDATED_AT = i18n.translate('xpack.csp.updated_at', {
+  defaultMessage: 'Updated at',
+});
+
+export const ENABLED = i18n.translate('xpack.csp.enabled', {
+  defaultMessage: 'Enabled',
+});
+
+export const MISSING_RULES = i18n.translate('xpack.csp.missing_rules', {
+  defaultMessage: 'Rules are missing',
+});

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/use_csp_rules.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/use_csp_rules.ts
@@ -6,10 +6,7 @@
  */
 import { useQuery, useMutation, useQueryClient } from 'react-query';
 import { cspRuleAssetSavedObjectType, type CspRuleSchema } from '../../../common/schemas/csp_rule';
-import type {
-  SavedObjectsBatchResponse,
-  SavedObjectsFindOptions,
-} from '../../../../../../src/core/public';
+import type { SavedObjectsFindOptions } from '../../../../../../src/core/public';
 import { useKibana } from '../../common/hooks/use_kibana';
 
 export type UseCspRulesOptions = Pick<
@@ -32,7 +29,7 @@ export const useFindCspRules = ({
         search,
         searchFields,
         page,
-        // NOTE: 'name.raw' is a field maping we defined on 'name' so it'd also be sortable
+        // NOTE: 'name.raw' is a field mapping we defined on 'name' so it'd also be sortable
         // TODO: this needs to be shared or removed
         sortField: 'name.raw',
         perPage,
@@ -47,14 +44,13 @@ export const useBulkUpdateCspRules = () => {
 
   return useMutation(
     (rules: CspRuleSchema[]) =>
-      savedObjects.client.bulkUpdate(
+      savedObjects.client.bulkUpdate<CspRuleSchema>(
         rules.map((rule) => ({
           type: cspRuleAssetSavedObjectType,
           id: rule.id,
           attributes: rule,
         }))
-        // TODO: fix bulkUpdate types in core
-      ) as Promise<SavedObjectsBatchResponse<CspRuleSchema>>,
+      ),
     {
       onSettled: () =>
         queryClient.invalidateQueries({


### PR DESCRIPTION
issue:
- https://github.com/elastic/security-team/issues/2765

this PR builds on previous PRs: #115, #119, #120 (all merged), and adds support for:

- [x] table with searchable rules (paginated & sorted).
- [x] rules as saved object with toggling for `enabled` property

note:  rules are currently global, with no relation to an integration instance. 

future work on table UX is tracked on [other issues](https://github.com/orgs/elastic/projects/705/views/8?filterQuery=-no%3Astatus+assignee%3A+orouz+sprint%3A6+), but please try out the branch and LMK if you run into issues as most of the work is done here, excluding refinements:
 - https://github.com/build-security/kibana/pull/140

also note there's multiple commits to smooth up the diff
