### PR TITLE
fix findings error handling

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/use_findings.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/use_findings.ts
@@ -67,9 +67,10 @@ const mapEsQuerySortKey = (sort: readonly EsQuerySortValue[]): EsQuerySortValue[
   }, []);
 
 const showResponseErrorToast =
-  ({ toasts: { addDanger } }: CoreStart['notifications']) =>
+  ({ toasts }: CoreStart['notifications']) =>
   (error: unknown): void => {
-    addDanger(extractErrorMessage(error, TEXT.SEARCH_FAILED));
+    if (error instanceof Error) toasts.addError(error, { title: TEXT.SEARCH_FAILED });
+    else toasts.addDanger(extractErrorMessage(error, TEXT.SEARCH_FAILED));
   };
 
 const extractFindings = ({


### PR DESCRIPTION
fixes a regression where a search error didn't propagate to the user

([added](https://github.com/build-security/kibana/pull/106/files#diff-8f087a4ce85aa027935504a6dfca3e149ff754fe5a7c662ce4c2dbca2796015fR39-R43) recently by me)

now it does, and looks like this:
![Screen Shot 2022-02-10 at 12 39 57](https://user-images.githubusercontent.com/20814186/153390325-1020b190-bb78-452e-afff-c1d82ed76fa6.png)


essentially passing the `Error.message`  down if there is any, defaulting to `Search Failed` if not. 

we can iterate on the display part, this PR mainly fixes the UI from going to invalid state.