### PR TITLE
Add rules config to package policy instance

### DIFF
--- a/x-pack/plugins/cloud_security_posture/common/constants.ts
+++ b/x-pack/plugins/cloud_security_posture/common/constants.ts
@@ -8,6 +8,7 @@
 export const STATS_ROUTE_PATH = '/api/csp/stats';
 export const FINDINGS_ROUTE_PATH = '/api/csp/findings';
 export const BENCHMARKS_ROUTE_PATH = '/api/csp/benchmarks';
+export const UPDATE_RULES_CONFIG_ROUTE_PATH = '/api/csp/update_rules_config';
 
 export const CSP_KUBEBEAT_INDEX_PATTERN = 'logs-k8s_cis*';
 export const AGENT_LOGS_INDEX_PATTERN = '.logs-k8s_cis.metadata*';

--- a/x-pack/plugins/cloud_security_posture/common/schemas/csp_configuration.ts
+++ b/x-pack/plugins/cloud_security_posture/common/schemas/csp_configuration.ts
@@ -6,10 +6,10 @@
  */
 import { schema as rt, TypeOf } from '@kbn/config-schema';
 
-export const cspConfigSchema = rt.object({
+export const cspRulesConfigSchema = rt.object({
   activated_rules: rt.object({
     cis_k8s: rt.arrayOf(rt.string()),
   }),
 });
 
-export type CspConfigSchema = TypeOf<typeof cspConfigSchema>;
+export type CspRulesConfigSchema = TypeOf<typeof cspRulesConfigSchema>;

--- a/x-pack/plugins/cloud_security_posture/common/schemas/csp_configuration.ts
+++ b/x-pack/plugins/cloud_security_posture/common/schemas/csp_configuration.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { schema as rt, TypeOf } from '@kbn/config-schema';
+
+export const cspConfigSchema = rt.object({
+  activated_rules: rt.object({
+    cis_k8s: rt.arrayOf(rt.string()),
+  }),
+});
+
+export type CspConfigSchema = TypeOf<typeof cspConfigSchema>;

--- a/x-pack/plugins/cloud_security_posture/server/routes/benchmarks/benchmarks.test.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/benchmarks/benchmarks.test.ts
@@ -10,7 +10,7 @@ import {
   benchmarksInputSchema,
   DEFAULT_BENCHMARKS_PER_PAGE,
   PACKAGE_POLICY_SAVED_OBJECT_TYPE,
-  getPackagePolicies,
+  getCspPackagePolicies,
   getAgentPolicies,
   createBenchmarkEntry,
 } from './benchmarks';
@@ -97,25 +97,15 @@ describe('benchmarks API', () => {
     });
 
     describe('test getPackagePolicies', () => {
-      it('should throw when agentPolicyService is undefined', async () => {
-        const mockAgentPolicyService = undefined;
-        expect(
-          getPackagePolicies(mockSoClient, mockAgentPolicyService, 'myPackage', {
-            page: 1,
-            per_page: 100,
-          })
-        ).rejects.toThrow();
-      });
-
       it('should format request by package name', async () => {
-        const mockAgentPolicyService = createPackagePolicyServiceMock();
+        const mockPackagePolicyService = createPackagePolicyServiceMock();
 
-        await getPackagePolicies(mockSoClient, mockAgentPolicyService, 'myPackage', {
+        await getCspPackagePolicies(mockSoClient, mockPackagePolicyService, 'myPackage', {
           page: 1,
           per_page: 100,
         });
 
-        expect(mockAgentPolicyService.list.mock.calls[0][1]).toMatchObject(
+        expect(mockPackagePolicyService.list.mock.calls[0][1]).toMatchObject(
           expect.objectContaining({
             kuery: `${PACKAGE_POLICY_SAVED_OBJECT_TYPE}.package.name:myPackage`,
             page: 1,

--- a/x-pack/plugins/cloud_security_posture/server/routes/benchmarks/benchmarks.test.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/benchmarks/benchmarks.test.ts
@@ -10,7 +10,7 @@ import {
   benchmarksInputSchema,
   DEFAULT_BENCHMARKS_PER_PAGE,
   PACKAGE_POLICY_SAVED_OBJECT_TYPE,
-  getCspPackagePolicies,
+  getPackagePolicies,
   getAgentPolicies,
   createBenchmarkEntry,
 } from './benchmarks';
@@ -100,7 +100,7 @@ describe('benchmarks API', () => {
       it('should format request by package name', async () => {
         const mockPackagePolicyService = createPackagePolicyServiceMock();
 
-        await getCspPackagePolicies(mockSoClient, mockPackagePolicyService, 'myPackage', {
+        await getPackagePolicies(mockSoClient, mockPackagePolicyService, 'myPackage', {
           page: 1,
           per_page: 100,
         });

--- a/x-pack/plugins/cloud_security_posture/server/routes/benchmarks/benchmarks.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/benchmarks/benchmarks.ts
@@ -43,22 +43,22 @@ export interface Benchmark {
 export const DEFAULT_BENCHMARKS_PER_PAGE = 20;
 export const PACKAGE_POLICY_SAVED_OBJECT_TYPE = 'ingest-package-policies';
 
-export const getCspPackagesNamesQuery = (packageName: string): string => {
+export const getPackageNameQuery = (packageName: string): string => {
   return `${PACKAGE_POLICY_SAVED_OBJECT_TYPE}.package.name:${packageName}`;
 };
 
-export const getCspPackagePolicies = async (
+export const getPackagePolicies = async (
   soClient: SavedObjectsClientContract,
   packagePolicyService: PackagePolicyServiceInterface,
   packageName: string,
-  queryParams?: BenchmarksQuerySchema
+  queryParams: BenchmarksQuerySchema
 ): Promise<PackagePolicy[]> => {
-  const packageNameQuery = getCspPackagesNamesQuery(packageName);
+  const packageNameQuery = getPackageNameQuery(packageName);
 
   const { items: packagePolicies } = (await packagePolicyService?.list(soClient, {
     kuery: packageNameQuery,
-    page: queryParams?.page,
-    perPage: queryParams?.per_page,
+    page: queryParams.page,
+    perPage: queryParams.per_page,
   })) ?? { items: [] as PackagePolicy[] };
 
   return packagePolicies;
@@ -155,7 +155,7 @@ export const defineGetBenchmarksRoute = (router: IRouter, cspContext: CspAppCont
           throw new Error(`Failed to get Fleet services`);
         }
 
-        const packagePolicies = await getCspPackagePolicies(
+        const packagePolicies = await getPackagePolicies(
           soClient,
           packagePolicyService,
           CIS_KUBERNETES_PACKAGE_NAME,

--- a/x-pack/plugins/cloud_security_posture/server/routes/benchmarks/benchmarks.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/benchmarks/benchmarks.ts
@@ -150,7 +150,6 @@ export const defineGetBenchmarksRoute = (router: IRouter, cspContext: CspAppCont
         const agentPolicyService = cspContext.service.agentPolicyService;
         const packagePolicyService = cspContext.service.packagePolicyService;
 
-        // TODO: This validate can be remove after #2819 will be merged
         if (!agentPolicyService || !agentService || !packagePolicyService) {
           throw new Error(`Failed to get Fleet services`);
         }

--- a/x-pack/plugins/cloud_security_posture/server/routes/configuration/save_data_yaml.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/configuration/save_data_yaml.ts
@@ -1,0 +1,168 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { produce } from 'immer';
+import { schema as rt } from '@kbn/config-schema';
+import { unset } from 'lodash';
+
+import type {
+  ElasticsearchClient,
+  IRouter,
+  SavedObjectsClientContract,
+  SavedObjectsFindResponse,
+} from 'src/core/server';
+
+import { transformError } from '@kbn/securitysolution-es-utils';
+import yaml from 'js-yaml';
+
+import { CspConfigSchema } from '../../../common/schemas/csp_configuration';
+import { CspAppContext } from '../../plugin';
+import { SAVE_DATA_YAML_ROUTE_PATH } from '../../../common/constants';
+import { CspRuleSchema, cspRuleAssetSavedObjectType } from '../../../common/schemas/csp_rule';
+import { PackagePolicyServiceInterface } from '../../../../fleet/server';
+import { PackagePolicy, PackagePolicyConfigRecord } from '../../../../fleet/common';
+import { CIS_KUBERNETES_PACKAGE_NAME } from '../../../common/constants';
+import { PackagePolicyService } from '../../../../fleet/server/services/package_policy';
+
+export const DEFAULT_FINDINGS_PER_PAGE = 20;
+
+const getCspRule = async (soClient: SavedObjectsClientContract) => {
+  const cspRules = await soClient.find<CspRuleSchema>({
+    type: cspRuleAssetSavedObjectType,
+    search: '',
+    searchFields: ['name'],
+    page: 1,
+    sortField: 'name.raw',
+    perPage: 10,
+  });
+  return cspRules;
+};
+
+const createConfig = async (
+  cspRules: SavedObjectsFindResponse<CspRuleSchema>
+): Promise<CspConfigSchema> => {
+  const activatedRules = cspRules.saved_objects.filter(
+    (cspRule) => cspRule.attributes.enabled === true
+  );
+  const config = {
+    activated_rules: {
+      cis_k8s: activatedRules.map((activatedRule) => activatedRule.id),
+    },
+  };
+  return config;
+};
+
+const convertConfigToYaml = (config: CspConfigSchema): string => {
+  return yaml.safeDump(config);
+};
+
+export const PACKAGE_POLICY_SAVED_OBJECT_TYPE = 'ingest-package-policies';
+
+export const getPackageNameQuery = (packageName: string): string => {
+  return `${PACKAGE_POLICY_SAVED_OBJECT_TYPE}.package.name:${packageName}`;
+};
+
+const setVarToPackagePolicy = (packagePolicy: PackagePolicy, dataYaml: string): PackagePolicy => {
+  const configFile: PackagePolicyConfigRecord = {
+    dataYaml: { type: 'config', value: dataYaml },
+  };
+  const updatedPackagePolicy = produce(packagePolicy, (draft) => {
+    unset(draft, 'id');
+    draft.vars = configFile;
+  });
+  return updatedPackagePolicy;
+};
+
+const updatePackagePolicy = async (
+  packagePolicyService: PackagePolicyService,
+  packagePolicies: PackagePolicy[],
+  esClient: ElasticsearchClient,
+  soClient: SavedObjectsClientContract,
+  dataYaml: string
+): Promise<PackagePolicy[]> => {
+  const updatedPackagePolicies = Promise.all(
+    packagePolicies.map((packagePolicy) => {
+      const updatedPackagePolicy = setVarToPackagePolicy(packagePolicy, dataYaml);
+      return packagePolicyService?.update(
+        soClient,
+        esClient,
+        packagePolicy.id,
+        updatedPackagePolicy
+      );
+    })
+  );
+  return updatedPackagePolicies;
+};
+
+export const getPackagePolicies = async (
+  soClient: SavedObjectsClientContract,
+  packagePolicyService: PackagePolicyServiceInterface | undefined,
+  packageName: string
+): Promise<PackagePolicy[]> => {
+  if (!packagePolicyService) {
+    throw new Error('packagePolicyService is undefined');
+  }
+
+  const packageNameQuery = getPackageNameQuery(packageName);
+
+  const { items: packagePolicies } = (await packagePolicyService?.list(soClient, {
+    kuery: packageNameQuery,
+    page: 1,
+    perPage: 20,
+  })) ?? { items: [] as PackagePolicy[] };
+
+  return packagePolicies;
+};
+
+export const defineSaveDataYamlRoute = (router: IRouter, cspContext: CspAppContext): void =>
+  router.get(
+    {
+      path: SAVE_DATA_YAML_ROUTE_PATH,
+      validate: { query: schema },
+    },
+    async (context, request, response) => {
+      try {
+        const esClient = context.core.elasticsearch.client.asCurrentUser;
+        const soClient = context.core.savedObjects.client;
+
+        const cspRules = await getCspRule(soClient);
+        const config = await createConfig(cspRules);
+        const dataYaml = convertConfigToYaml(config);
+
+        const packagePolicyService = cspContext.service.packagePolicyService;
+        const packagePolicies = await getPackagePolicies(
+          soClient,
+          packagePolicyService,
+          CIS_KUBERNETES_PACKAGE_NAME
+        );
+
+        const updatedPackagePolicies = await updatePackagePolicy(
+          packagePolicyService!,
+          packagePolicies,
+          esClient,
+          soClient,
+          dataYaml
+        );
+
+        return response.ok({ body: updatedPackagePolicies });
+      } catch (err) {
+        const error = transformError(err);
+        cspContext.logger.error(
+          `Failed to update rules configuration on package policy ${error.message}`
+        );
+        return response.customError({
+          body: { message: error.message },
+          statusCode: error.statusCode,
+        });
+      }
+    }
+  );
+
+const schema = rt.object({
+  latest_cycle: rt.maybe(rt.boolean()),
+  page: rt.number({ defaultValue: 1, min: 0 }),
+  per_page: rt.number({ defaultValue: DEFAULT_FINDINGS_PER_PAGE, min: 0 }),
+});

--- a/x-pack/plugins/cloud_security_posture/server/routes/configuration/update_rules_configuration.test.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/configuration/update_rules_configuration.test.ts
@@ -142,7 +142,7 @@ describe('Update rules configuration API', () => {
     const mockPackagePolicy2 = createPackagePolicyMock();
     mockPackagePolicy1.id = packagePolicyId1;
     mockPackagePolicy2.id = packagePolicyId2;
-    const packagePolicies = [mockPackagePolicy1, mockPackagePolicy2];
+    const packagePolicies = mockPackagePolicy1;
 
     const dataYaml = 'activated_rules:\n  cis_k8s:\n    - 1.1.1\n    - 1.1.2\n';
 
@@ -154,8 +154,7 @@ describe('Update rules configuration API', () => {
       dataYaml
     );
 
-    expect(mockPackagePolicyService.update).toBeCalledTimes(2);
+    expect(mockPackagePolicyService.update).toBeCalledTimes(1);
     expect(mockPackagePolicyService.update.mock.calls[0][2]).toEqual(packagePolicyId1);
-    expect(mockPackagePolicyService.update.mock.calls[1][2]).toEqual(packagePolicyId2);
   });
 });

--- a/x-pack/plugins/cloud_security_posture/server/routes/configuration/update_rules_configuration.test.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/configuration/update_rules_configuration.test.ts
@@ -50,7 +50,7 @@ describe('Update rules configuration API', () => {
     };
     defineUpdateRulesConfigRoute(router, cspContext);
 
-    const [config, _] = router.get.mock.calls[0];
+    const [config, _] = router.post.mock.calls[0];
 
     expect(config.path).toEqual('/api/csp/update_rules_config');
   });

--- a/x-pack/plugins/cloud_security_posture/server/routes/configuration/update_rules_configuration.test.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/configuration/update_rules_configuration.test.ts
@@ -1,0 +1,161 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+// eslint-disable-next-line @kbn/eslint/no-restricted-paths
+import { elasticsearchClientMock } from 'src/core/server/elasticsearch/client/mocks';
+import { savedObjectsClientMock, httpServiceMock, loggingSystemMock } from 'src/core/server/mocks';
+import {
+  convertRulesConfigToYaml,
+  createRulesConfig,
+  defineUpdateRulesConfigRoute,
+  getCspRules,
+  setVarToPackagePolicy,
+  updatePackagePolicy,
+} from './update_rules_configuration';
+
+import { CspAppService } from '../../lib/csp_app_services';
+import { CspAppContext } from '../../plugin';
+import { createPackagePolicyMock } from '../../../../fleet/common/mocks';
+import { createPackagePolicyServiceMock } from '../../../../fleet/server/mocks';
+
+import { cspRuleAssetSavedObjectType, CspRuleSchema } from '../../../common/schemas/csp_rule';
+import {
+  ElasticsearchClient,
+  SavedObjectsClientContract,
+  SavedObjectsFindResponse,
+} from 'kibana/server';
+import { Chance } from 'chance';
+
+describe('Update rules configuration API', () => {
+  let logger: ReturnType<typeof loggingSystemMock.createLogger>;
+  let mockEsClient: jest.Mocked<ElasticsearchClient>;
+  let mockSoClient: jest.Mocked<SavedObjectsClientContract>;
+  const chance = new Chance();
+
+  beforeEach(() => {
+    logger = loggingSystemMock.createLogger();
+    jest.clearAllMocks();
+  });
+
+  it('validate the API route path', async () => {
+    const router = httpServiceMock.createRouter();
+    const cspAppContextService = new CspAppService();
+
+    const cspContext: CspAppContext = {
+      logger,
+      service: cspAppContextService,
+    };
+    defineUpdateRulesConfigRoute(router, cspContext);
+
+    const [config, _] = router.get.mock.calls[0];
+
+    expect(config.path).toEqual('/api/csp/update_rules_config');
+  });
+
+  it('validate getCspRules input parameters', async () => {
+    mockSoClient = savedObjectsClientMock.create();
+    mockSoClient.find.mockResolvedValueOnce({} as SavedObjectsFindResponse);
+    await getCspRules(mockSoClient);
+    expect(mockSoClient.find).toBeCalledTimes(1);
+    expect(mockSoClient.find).toHaveBeenCalledWith(
+      expect.objectContaining({ type: cspRuleAssetSavedObjectType })
+    );
+  });
+
+  it('create csp rules config based on activated csp rules', async () => {
+    const cspRules = {
+      page: 1,
+      per_page: 1000,
+      total: 2,
+      saved_objects: [
+        {
+          type: 'csp_rule',
+          id: '1.1.1',
+          attributes: { enabled: true },
+        },
+        {
+          type: 'csp_rule',
+          id: '1.1.2',
+          attributes: { enabled: false },
+        },
+        {
+          type: 'csp_rule',
+          id: '1.1.3',
+          attributes: { enabled: true },
+        },
+      ],
+    } as SavedObjectsFindResponse<CspRuleSchema>;
+    const cspConfig = await createRulesConfig(cspRules);
+    expect(cspConfig).toMatchObject({ activated_rules: { cis_k8s: ['1.1.1', '1.1.3'] } });
+  });
+
+  it('create empty csp rules config when all rules are disabled', async () => {
+    const cspRules = {
+      page: 1,
+      per_page: 1000,
+      total: 2,
+      saved_objects: [
+        {
+          type: 'csp_rule',
+          id: '1.1.1',
+          attributes: { enabled: false },
+        },
+        {
+          type: 'csp_rule',
+          id: '1.1.2',
+          attributes: { enabled: false },
+        },
+      ],
+    } as SavedObjectsFindResponse<CspRuleSchema>;
+    const cspConfig = await createRulesConfig(cspRules);
+    expect(cspConfig).toMatchObject({ activated_rules: { cis_k8s: [] } });
+  });
+
+  it('validate converting rules config object to Yaml', async () => {
+    const cspRuleConfig = { activated_rules: { cis_k8s: ['1.1.1', '1.1.2'] } };
+
+    const dataYaml = convertRulesConfigToYaml(cspRuleConfig);
+
+    expect(dataYaml).toEqual('activated_rules:\n  cis_k8s:\n    - 1.1.1\n    - 1.1.2\n');
+  });
+
+  it('validate adding new data.yaml to package policy instance', async () => {
+    const packagePolicy = createPackagePolicyMock();
+
+    const dataYaml = 'activated_rules:\n  cis_k8s:\n    - 1.1.1\n    - 1.1.2\n';
+    const updatedPackagePolicy = setVarToPackagePolicy(packagePolicy, dataYaml);
+
+    expect(updatedPackagePolicy.vars).toEqual({ dataYaml: { type: 'config', value: dataYaml } });
+  });
+
+  it('validate updatePackagePolicy is called with the right parameters', async () => {
+    mockEsClient = elasticsearchClientMock.createClusterClient().asScoped().asInternalUser;
+    mockSoClient = savedObjectsClientMock.create();
+    const mockPackagePolicyService = createPackagePolicyServiceMock();
+
+    const packagePolicyId1 = chance.guid();
+    const packagePolicyId2 = chance.guid();
+    const mockPackagePolicy1 = createPackagePolicyMock();
+    const mockPackagePolicy2 = createPackagePolicyMock();
+    mockPackagePolicy1.id = packagePolicyId1;
+    mockPackagePolicy2.id = packagePolicyId2;
+    const packagePolicies = [mockPackagePolicy1, mockPackagePolicy2];
+
+    const dataYaml = 'activated_rules:\n  cis_k8s:\n    - 1.1.1\n    - 1.1.2\n';
+
+    await updatePackagePolicy(
+      mockPackagePolicyService,
+      packagePolicies,
+      mockEsClient,
+      mockSoClient,
+      dataYaml
+    );
+
+    expect(mockPackagePolicyService.update).toBeCalledTimes(2);
+    expect(mockPackagePolicyService.update.mock.calls[0][2]).toEqual(packagePolicyId1);
+    expect(mockPackagePolicyService.update.mock.calls[1][2]).toEqual(packagePolicyId2);
+  });
+});

--- a/x-pack/plugins/cloud_security_posture/server/routes/configuration/update_rules_configuration.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/configuration/update_rules_configuration.ts
@@ -100,7 +100,7 @@ export const updatePackagePolicy = (
 };
 
 export const defineUpdateRulesConfigRoute = (router: IRouter, cspContext: CspAppContext): void =>
-  router.get(
+  router.post(
     {
       path: UPDATE_RULES_CONFIG_ROUTE_PATH,
       validate: { query: configurationUpdateInputSchema },
@@ -112,7 +112,6 @@ export const defineUpdateRulesConfigRoute = (router: IRouter, cspContext: CspApp
         const packagePolicyService = cspContext.service.packagePolicyService;
         const packagePolicyId = request.query.package_policy_id;
 
-        // TODO: This validate can be remove after #2819 will be merged
         if (!packagePolicyService) {
           throw new Error(`Failed to get Fleet services`);
         }

--- a/x-pack/plugins/cloud_security_posture/server/routes/configuration/update_rules_configuration.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/configuration/update_rules_configuration.ts
@@ -34,11 +34,11 @@ export const getPackagePolicy = async (
 
   // PackagePolicies always contains one element, even when package does not exist
   if (!packagePolicies || !packagePolicies[0].version) {
-    throw new Error(`package policy Id ${packagePolicyId} is not exist`);
+    throw new Error(`package policy Id '${packagePolicyId}' is not exist`);
   }
   if (packagePolicies[0].package?.name !== CIS_KUBERNETES_PACKAGE_NAME) {
     // TODO: improve this validator to support any future CSP package
-    throw new Error(`Package Policy Id ${packagePolicyId} is not CSP package`);
+    throw new Error(`Package Policy Id '${packagePolicyId}' is not CSP package`);
   }
 
   return packagePolicies![0];

--- a/x-pack/plugins/cloud_security_posture/server/routes/configuration/update_rules_configuration.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/configuration/update_rules_configuration.ts
@@ -20,7 +20,7 @@ import { PackagePolicy, PackagePolicyConfigRecord } from '../../../../fleet/comm
 import { CspAppContext } from '../../plugin';
 import { CspRulesConfigSchema } from '../../../common/schemas/csp_configuration';
 import { CspRuleSchema, cspRuleAssetSavedObjectType } from '../../../common/schemas/csp_rule';
-import { getCspPackagePolicies } from '../benchmarks/benchmarks';
+import { getPackagePolicies } from '../benchmarks/benchmarks';
 import { UPDATE_RULES_CONFIG_ROUTE_PATH } from '../../../common/constants';
 import { CIS_KUBERNETES_PACKAGE_NAME } from '../../../common/constants';
 import { PackagePolicyServiceInterface } from '../../../../fleet/server';
@@ -111,7 +111,7 @@ export const defineUpdateRulesConfigRoute = (router: IRouter, cspContext: CspApp
         const rulesConfig = createRulesConfig(cspRules);
         const dataYaml = convertRulesConfigToYaml(rulesConfig);
 
-        const packagePolicies = await getCspPackagePolicies(
+        const packagePolicies = await getPackagePolicies(
           soClient,
           packagePolicyService,
           CIS_KUBERNETES_PACKAGE_NAME,

--- a/x-pack/plugins/cloud_security_posture/server/routes/index.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/index.ts
@@ -9,10 +9,12 @@ import type { IRouter } from '../../../../../src/core/server';
 import { defineGetStatsRoute } from './stats/stats';
 import { defineGetBenchmarksRoute } from './benchmarks/benchmarks';
 import { defineFindingsIndexRoute as defineGetFindingsIndexRoute } from './findings/findings';
+import { defineUpdateRulesConfigRoute } from './configuration/update_rules_configuration';
 import { CspAppContext } from '../plugin';
 
 export function defineRoutes(router: IRouter, cspContext: CspAppContext) {
   defineGetStatsRoute(router, cspContext);
   defineGetFindingsIndexRoute(router, cspContext);
   defineGetBenchmarksRoute(router, cspContext);
+  defineUpdateRulesConfigRoute(router, cspContext);
 }


### PR DESCRIPTION
Add support for updating dataYaml for specific package. 
To test the endpoint:
1. checkout the integration branch: https://github.com/build-security/integrations/pull/12
2. compile the new package
3. add `CIS Kubernetes Benchmark integration` Integration
4. fetch the integration instance id (inspect the package page)
5. call the API with:
```
curl --location --request GET 'http://localhost:5601/api/csp/update_rules_config?package_policy_id=b62ba402-ef79-4f2e-b3c2-6e6e60d226d9' \
--header 'Authorization: Basic ZWxhc3RpYzpjaGFuZ2VtZQ==' \
--header 'kbn-xsrf;'
```