### PR TITLE
Rules Table bulk UX

### DIFF
--- a/x-pack/plugins/cloud_security_posture/common/utils/helpers.ts
+++ b/x-pack/plugins/cloud_security_posture/common/utils/helpers.ts
@@ -4,7 +4,6 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
 
 /**
  * @example
@@ -16,7 +15,7 @@ export const isNonNullable = <T extends unknown>(v: T): v is NonNullable<T> =>
 
 export const extractErrorMessage = (e: unknown, defaultMessage = 'Unknown Error'): string => {
   if (e instanceof Error) return e.message;
-  if (t.record(t.literal('message'), t.string).is(e)) return e.message;
+  if (typeof e === 'string') return e;
 
   return defaultMessage; // TODO: i18n
 };

--- a/x-pack/plugins/cloud_security_posture/public/common/navigation/constants.ts
+++ b/x-pack/plugins/cloud_security_posture/public/common/navigation/constants.ts
@@ -12,7 +12,7 @@ import type { CspPage, CspNavigationItem } from './types';
 export const allNavigationItems: Record<CspPage, CspNavigationItem> = {
   dashboard: { name: TEXT.DASHBOARD, path: '/dashboard' },
   findings: { name: TEXT.FINDINGS, path: '/findings' },
-  rules: { name: 'Rules', path: '/rules', disabled: true },
+  rules: { name: 'Rules', path: '/rules', disabled: false },
   benchmarks: {
     name: TEXT.MY_BENCHMARKS,
     path: '/benchmarks',

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/index.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/index.tsx
@@ -7,6 +7,7 @@
 import React from 'react';
 import type { EuiPageHeaderProps } from '@elastic/eui';
 import { CspPageTemplate } from '../../components/page_template';
+import { RulesContainer } from './rules_container';
 
 // TODO:
 // - get selected integration
@@ -16,5 +17,9 @@ const pageHeader: EuiPageHeaderProps = {
 };
 
 export const Rules = () => {
-  return <CspPageTemplate pageHeader={pageHeader} />;
+  return (
+    <CspPageTemplate pageHeader={pageHeader}>
+      <RulesContainer />
+    </CspPageTemplate>
+  );
 };

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_bottom_bar.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_bottom_bar.tsx
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React from 'react';
+import { EuiFlexGroup, EuiFlexItem, EuiBottomBar, EuiButton } from '@elastic/eui';
+import * as TEST_SUBJECTS from './test_subjects';
+import * as TEXT from './translations';
+
+interface RulesBottomBarProps {
+  onSave(): void;
+  onCancel(): void;
+  isLoading: boolean;
+}
+
+export const RulesBottomBar = ({ onSave, onCancel, isLoading }: RulesBottomBarProps) => (
+  <EuiBottomBar>
+    <EuiFlexGroup justifyContent="flexEnd">
+      <EuiFlexItem grow={false}>
+        <EuiButton size="m" iconType="cross" isLoading={isLoading} onClick={onCancel} color="ghost">
+          {TEXT.CANCEL}
+        </EuiButton>
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiButton
+          size="m"
+          iconType="save"
+          isLoading={isLoading}
+          onClick={onSave}
+          fill
+          data-test-subj={TEST_SUBJECTS.CSP_RULES_SAVE_BUTTON}
+        >
+          {TEXT.SAVE}
+        </EuiButton>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  </EuiBottomBar>
+);

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_bulk_actions_menu.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_bulk_actions_menu.tsx
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React, { useState } from 'react';
+import {
+  EuiContextMenuPanel,
+  EuiContextMenuItem,
+  EuiPopover,
+  useGeneratedHtmlId,
+  EuiButtonEmpty,
+  type EuiContextMenuItemProps,
+} from '@elastic/eui';
+import * as TEST_SUBJECTS from './test_subjects';
+import * as TEXT from './translations';
+
+interface RulesBulkActionsMenuProps {
+  items: ReadonlyArray<EuiContextMenuItemProps & { text: JSX.Element }>;
+}
+
+export const RulesBulkActionsMenu = ({ items }: RulesBulkActionsMenuProps) => {
+  const [isPopoverOpen, setPopover] = useState(false);
+  const smallContextMenuPopoverId = useGeneratedHtmlId({
+    prefix: 'smallContextMenuPopover',
+  });
+
+  const onButtonClick = () => setPopover(!isPopoverOpen);
+
+  const closePopover = () => setPopover(false);
+
+  const data = items.map((item, i) => (
+    <EuiContextMenuItem
+      {...item}
+      key={i}
+      children={item.text}
+      onClick={(e) => {
+        closePopover();
+        item.onClick?.(e);
+      }}
+    />
+  ));
+
+  const button = (
+    <EuiButtonEmpty
+      iconType={'arrowDown'}
+      onClick={onButtonClick}
+      data-test-subj={TEST_SUBJECTS.CSP_RULES_TABLE_BULK_MENU_BUTTON}
+    >
+      {TEXT.BULK_ACTIONS}
+    </EuiButtonEmpty>
+  );
+
+  return (
+    <EuiPopover
+      id={smallContextMenuPopoverId}
+      button={button}
+      isOpen={isPopoverOpen}
+      closePopover={closePopover}
+      panelPaddingSize="none"
+      anchorPosition="downLeft"
+    >
+      <EuiContextMenuPanel size="s" items={data} />
+    </EuiPopover>
+  );
+};

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_container.test.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_container.test.tsx
@@ -6,10 +6,10 @@
  */
 
 import React from 'react';
-import { RulesContainer, type RuleSavedObject } from './rules_container';
+import { RulesContainer } from './rules_container';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { QueryClient } from 'react-query';
-import { useFindCspRules, useBulkUpdateCspRules } from './use_csp_rules';
+import { useFindCspRules, useBulkUpdateCspRules, type RuleSavedObject } from './use_csp_rules';
 import * as TEST_SUBJECTS from './test_subjects';
 import { Chance } from 'chance';
 import { TestProvider } from '../../test/test_provider';

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_container.test.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_container.test.tsx
@@ -1,0 +1,306 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { RulesContainer, type RuleSavedObject } from './rules_container';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { QueryClient } from 'react-query';
+import { useFindCspRules, useBulkUpdateCspRules } from './use_csp_rules';
+import * as TEST_SUBJECTS from './test_subjects';
+import { Chance } from 'chance';
+import { TestProvider } from '../../test/test_provider';
+
+const chance = new Chance();
+
+jest.mock('./use_csp_rules', () => ({
+  useFindCspRules: jest.fn(),
+  useBulkUpdateCspRules: jest.fn(),
+}));
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: { retry: false },
+  },
+});
+
+const getWrapper =
+  (): React.FC =>
+  ({ children }) =>
+    <TestProvider>{children}</TestProvider>;
+
+const getFakeRule = ({ id = chance.guid(), enabled }: { id?: string; enabled: boolean }) =>
+  ({
+    id,
+    updated_at: chance.date().toISOString(),
+    attributes: {
+      id,
+      name: chance.word(),
+      enabled,
+    },
+  } as RuleSavedObject);
+
+const useFindCspRulesMock = (value: any) => (useFindCspRules as jest.Mock).mockReturnValue(value);
+
+describe('<RulesContainer />', () => {
+  beforeEach(() => {
+    queryClient.clear();
+    jest.clearAllMocks();
+    (useBulkUpdateCspRules as jest.Mock).mockReturnValue({
+      status: 'idle',
+      mutate: jest.fn(),
+    });
+  });
+
+  it('displays rules with their initial state', async () => {
+    const Wrapper = getWrapper();
+    const rule1 = getFakeRule({ enabled: true });
+
+    useFindCspRulesMock({
+      status: 'success',
+      data: {
+        total: 1,
+        savedObjects: [rule1],
+      },
+    });
+
+    render(
+      <Wrapper>
+        <RulesContainer />
+      </Wrapper>
+    );
+
+    expect(await screen.getByTestId(TEST_SUBJECTS.CSP_RULES_CONTAINER)).toBeInTheDocument();
+    expect(await screen.getByText(rule1.attributes.name)).toBeInTheDocument();
+    expect(
+      screen
+        .getByTestId(TEST_SUBJECTS.getCspRulesTableItemSwitchTestId(rule1.id))
+        .getAttribute('aria-checked')
+    ).toEqual('true');
+  });
+
+  it('toggles rules locally', () => {
+    const Wrapper = getWrapper();
+    const rule1 = getFakeRule({ enabled: false });
+    const rule2 = getFakeRule({ enabled: true });
+
+    useFindCspRulesMock({
+      status: 'success',
+      data: {
+        total: 2,
+        savedObjects: [rule1, rule2],
+      },
+    });
+
+    render(
+      <Wrapper>
+        <RulesContainer />
+      </Wrapper>
+    );
+
+    const switchId1 = TEST_SUBJECTS.getCspRulesTableItemSwitchTestId(rule1.id);
+    const switchId2 = TEST_SUBJECTS.getCspRulesTableItemSwitchTestId(rule2.id);
+
+    fireEvent.click(screen.getByTestId(switchId1));
+    fireEvent.click(screen.getByTestId(switchId2));
+
+    expect(screen.getByTestId(switchId1).getAttribute('aria-checked')).toEqual(
+      (!rule1.attributes.enabled).toString()
+    );
+    expect(screen.getByTestId(switchId2).getAttribute('aria-checked')).toEqual(
+      (!rule2.attributes.enabled).toString()
+    );
+  });
+
+  it('bulk toggles rules locally', () => {
+    const Wrapper = getWrapper();
+    const rule1 = getFakeRule({ enabled: true });
+    const rule2 = getFakeRule({ enabled: true });
+    const rule3 = getFakeRule({ enabled: false });
+
+    useFindCspRulesMock({
+      status: 'success',
+      data: {
+        total: 3,
+        savedObjects: [rule1, rule2, rule3],
+      },
+    });
+
+    render(
+      <Wrapper>
+        <RulesContainer />
+      </Wrapper>
+    );
+
+    const switchId1 = TEST_SUBJECTS.getCspRulesTableItemSwitchTestId(rule1.id);
+    const switchId2 = TEST_SUBJECTS.getCspRulesTableItemSwitchTestId(rule2.id);
+    const switchId3 = TEST_SUBJECTS.getCspRulesTableItemSwitchTestId(rule3.id);
+
+    fireEvent.click(screen.getByTestId('checkboxSelectAll'));
+    fireEvent.click(screen.getByTestId(TEST_SUBJECTS.CSP_RULES_TABLE_BULK_MENU_BUTTON));
+    fireEvent.click(screen.getByTestId(TEST_SUBJECTS.CSP_RULES_TABLE_BULK_DISABLE_BUTTON));
+
+    expect(screen.getByTestId(switchId1).getAttribute('aria-checked')).toEqual(
+      (!rule1.attributes.enabled).toString()
+    );
+    expect(screen.getByTestId(switchId2).getAttribute('aria-checked')).toEqual(
+      (!rule2.attributes.enabled).toString()
+    );
+    expect(screen.getByTestId(switchId3).getAttribute('aria-checked')).toEqual(
+      rule3.attributes.enabled.toString()
+    );
+  });
+
+  it('updates rules with local changes done by non-bulk toggles', () => {
+    const Wrapper = getWrapper();
+    const rule1 = getFakeRule({ enabled: false });
+    const rule2 = getFakeRule({ enabled: true });
+    const rule3 = getFakeRule({ enabled: true });
+
+    useFindCspRulesMock({
+      status: 'success',
+      data: {
+        total: 3,
+        savedObjects: [rule1, rule2, rule3],
+      },
+    });
+
+    render(
+      <Wrapper>
+        <RulesContainer />
+      </Wrapper>
+    );
+    const { mutate } = useBulkUpdateCspRules();
+
+    const switchId1 = TEST_SUBJECTS.getCspRulesTableItemSwitchTestId(rule1.id);
+    const switchId2 = TEST_SUBJECTS.getCspRulesTableItemSwitchTestId(rule2.id);
+    const switchId3 = TEST_SUBJECTS.getCspRulesTableItemSwitchTestId(rule3.id);
+
+    fireEvent.click(screen.getByTestId(switchId1));
+    fireEvent.click(screen.getByTestId(switchId2));
+    fireEvent.click(screen.getByTestId(switchId3)); // adds
+    fireEvent.click(screen.getByTestId(switchId3)); // removes
+    fireEvent.click(screen.getByTestId(TEST_SUBJECTS.CSP_RULES_SAVE_BUTTON));
+
+    expect(mutate).toHaveBeenCalledTimes(1);
+    expect(mutate).toHaveBeenCalledWith([
+      { ...rule1.attributes, enabled: !rule1.attributes.enabled },
+      { ...rule2.attributes, enabled: !rule2.attributes.enabled },
+    ]);
+  });
+
+  it('updates rules with local changes done by bulk toggles', () => {
+    const Wrapper = getWrapper();
+    const rule1 = getFakeRule({ enabled: false });
+    const rule2 = getFakeRule({ enabled: true });
+    const rule3 = getFakeRule({ enabled: true });
+
+    useFindCspRulesMock({
+      status: 'success',
+      data: {
+        total: 3,
+        savedObjects: [rule1, rule2, rule3],
+      },
+    });
+
+    render(
+      <Wrapper>
+        <RulesContainer />
+      </Wrapper>
+    );
+    const { mutate } = useBulkUpdateCspRules();
+
+    fireEvent.click(screen.getByTestId('checkboxSelectAll'));
+    fireEvent.click(screen.getByTestId(TEST_SUBJECTS.CSP_RULES_TABLE_BULK_MENU_BUTTON));
+    fireEvent.click(screen.getByTestId(TEST_SUBJECTS.CSP_RULES_TABLE_BULK_ENABLE_BUTTON)); // This should only change rule1
+    fireEvent.click(screen.getByTestId(TEST_SUBJECTS.CSP_RULES_SAVE_BUTTON));
+
+    expect(mutate).toHaveBeenCalledTimes(1);
+    expect(mutate).toHaveBeenCalledWith([
+      { ...rule1.attributes, enabled: !rule1.attributes.enabled },
+    ]);
+  });
+
+  it('only changes selected rules in bulk operations', () => {
+    const Wrapper = getWrapper();
+    const rule1 = getFakeRule({ enabled: false });
+    const rule2 = getFakeRule({ enabled: true });
+    const rule3 = getFakeRule({ enabled: false });
+    const rule4 = getFakeRule({ enabled: false });
+    const rule5 = getFakeRule({ enabled: true });
+
+    useFindCspRulesMock({
+      status: 'success',
+      data: {
+        total: 4,
+        savedObjects: [rule1, rule2, rule3, rule4, rule5],
+      },
+    });
+
+    render(
+      <Wrapper>
+        <RulesContainer />
+      </Wrapper>
+    );
+    const { mutate } = useBulkUpdateCspRules();
+
+    fireEvent.click(screen.getByTestId(`checkboxSelectRow-${rule1.id}`)); // changes
+    fireEvent.click(screen.getByTestId(`checkboxSelectRow-${rule2.id}`)); // doesn't change
+    fireEvent.click(screen.getByTestId(`checkboxSelectRow-${rule4.id}`)); // changes
+    fireEvent.click(screen.getByTestId(TEST_SUBJECTS.CSP_RULES_TABLE_BULK_MENU_BUTTON));
+    fireEvent.click(screen.getByTestId(TEST_SUBJECTS.CSP_RULES_TABLE_BULK_ENABLE_BUTTON));
+    fireEvent.click(screen.getByTestId(TEST_SUBJECTS.getCspRulesTableItemSwitchTestId(rule5.id))); // changes
+    fireEvent.click(screen.getByTestId(TEST_SUBJECTS.CSP_RULES_SAVE_BUTTON));
+
+    expect(mutate).toHaveBeenCalledTimes(1);
+    expect(mutate).toHaveBeenCalledWith([
+      { ...rule1.attributes, enabled: !rule1.attributes.enabled },
+      { ...rule4.attributes, enabled: !rule4.attributes.enabled },
+      { ...rule5.attributes, enabled: !rule5.attributes.enabled },
+    ]);
+  });
+
+  it('updates rules with changes of both bulk/non-bulk toggles', () => {
+    const Wrapper = getWrapper();
+    const rule1 = getFakeRule({ enabled: false });
+    const rule2 = getFakeRule({ enabled: true });
+    const rule3 = getFakeRule({ enabled: false });
+    const rule4 = getFakeRule({ enabled: false });
+    const rule5 = getFakeRule({ enabled: true });
+
+    useFindCspRulesMock({
+      status: 'success',
+      data: {
+        total: 4,
+        savedObjects: [rule1, rule2, rule3, rule4, rule5],
+      },
+    });
+
+    render(
+      <Wrapper>
+        <RulesContainer />
+      </Wrapper>
+    );
+
+    const { mutate } = useBulkUpdateCspRules();
+
+    fireEvent.click(screen.getByTestId(`checkboxSelectRow-${rule1.id}`)); // changes rule1
+    fireEvent.click(screen.getByTestId(`checkboxSelectRow-${rule2.id}`)); // doesn't change
+    fireEvent.click(screen.getByTestId(`checkboxSelectRow-${rule4.id}`)); // changes rule4
+    fireEvent.click(screen.getByTestId(TEST_SUBJECTS.CSP_RULES_TABLE_BULK_MENU_BUTTON));
+    fireEvent.click(screen.getByTestId(TEST_SUBJECTS.CSP_RULES_TABLE_BULK_DISABLE_BUTTON)); // changes rule2
+    fireEvent.click(screen.getByTestId(TEST_SUBJECTS.CSP_RULES_TABLE_BULK_ENABLE_BUTTON)); // reverts rule2
+    fireEvent.click(screen.getByTestId(TEST_SUBJECTS.getCspRulesTableItemSwitchTestId(rule5.id))); // changes rule5
+    fireEvent.click(screen.getByTestId(TEST_SUBJECTS.CSP_RULES_SAVE_BUTTON));
+
+    expect(mutate).toHaveBeenCalledTimes(1);
+    expect(mutate).toHaveBeenCalledWith([
+      { ...rule1.attributes, enabled: !rule1.attributes.enabled },
+      { ...rule4.attributes, enabled: !rule4.attributes.enabled },
+      { ...rule5.attributes, enabled: !rule5.attributes.enabled },
+    ]);
+  });
+});

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_container.test.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_container.test.tsx
@@ -303,4 +303,42 @@ describe('<RulesContainer />', () => {
       { ...rule5.attributes, enabled: !rule5.attributes.enabled },
     ]);
   });
+
+  it('selects and updates all rules', async () => {
+    const Wrapper = getWrapper();
+    const enabled = true;
+    const rules = Array.from({ length: 20 }, (x, i) => getFakeRule({ enabled }));
+
+    useFindCspRulesMock({
+      status: 'success',
+      data: {
+        total: rules.length,
+        savedObjects: rules,
+      },
+    });
+
+    render(
+      <Wrapper>
+        <RulesContainer />
+      </Wrapper>
+    );
+
+    const { mutate } = useBulkUpdateCspRules();
+
+    fireEvent.click(screen.getByTestId(TEST_SUBJECTS.CSP_RULES_TABLE_SELECT_ALL_BUTTON));
+    fireEvent.click(screen.getByTestId(TEST_SUBJECTS.CSP_RULES_TABLE_BULK_MENU_BUTTON));
+    fireEvent.click(screen.getByTestId(TEST_SUBJECTS.CSP_RULES_TABLE_BULK_DISABLE_BUTTON));
+    fireEvent.click(screen.getByTestId(TEST_SUBJECTS.CSP_RULES_SAVE_BUTTON));
+
+    expect(
+      await screen.findByText(new RegExp(`Selected ${rules.length} rules`))
+    ).toBeInTheDocument();
+    expect(mutate).toHaveBeenCalledTimes(1);
+    expect(mutate).toHaveBeenCalledWith(
+      rules.map((rule) => ({
+        ...rule.attributes,
+        enabled: !enabled,
+      }))
+    );
+  });
 });

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_container.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_container.tsx
@@ -23,7 +23,12 @@ type SimpleRulesQueryResult = DistributivePick<RulesQueryResult, 'data' | 'error
 
 /** Rules with local changes */
 type LocalRulesResult =
-  | Exclude<SimpleRulesQueryResult, { status: 'success' }>
+  | Exclude<SimpleRulesQueryResult, { status: 'success' | 'error' }>
+  | {
+      status: 'error';
+      error: string;
+      data: undefined;
+    }
   | {
       status: 'success';
       error: null;
@@ -73,6 +78,7 @@ const getLocalRulesResult = (
     case 'error':
       return {
         ...result,
+        data: undefined,
         error: extractErrorMessage(result.error),
       };
     default:

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_container.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_container.tsx
@@ -1,0 +1,173 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React, { useEffect, useState, useMemo, useCallback } from 'react';
+import { EuiPanel } from '@elastic/eui';
+import { SavedObject } from 'src/core/public';
+import { extractErrorMessage } from '../../../common/utils/helpers';
+import { RulesTable } from './rules_table';
+import { RulesBottomBar } from './rules_bottom_bar';
+import { RulesTableHeader } from './rules_table_header';
+import type { CspRuleSchema } from '../../../common/schemas/csp_rule';
+import { useFindCspRules, useBulkUpdateCspRules, type UseCspRulesOptions } from './use_csp_rules';
+import * as TEST_SUBJECTS from './test_subjects';
+
+export type RuleSavedObject = SavedObject<CspRuleSchema>; // SimpleSavedObject
+
+type RulesQuery = Required<Omit<UseCspRulesOptions, 'searchFields'>>;
+type RulesQueryResult = ReturnType<typeof useFindCspRules>;
+type SimpleRulesQueryResult = DistributivePick<RulesQueryResult, 'data' | 'error' | 'status'>;
+
+/** Rules with local changes */
+type LocalRulesResult =
+  | Exclude<SimpleRulesQueryResult, { status: 'success' }>
+  | {
+      status: 'success';
+      error: null;
+      data: readonly RuleSavedObject[];
+      total: number;
+    };
+
+export type RulesState = LocalRulesResult & RulesQuery;
+
+const getSimpleQueryString = (searchValue?: string): string =>
+  searchValue ? `${searchValue}*` : '';
+
+const getChangedRules = (
+  baseRules: ReadonlyMap<string, RuleSavedObject>,
+  currentChangedRules: ReadonlyMap<string, RuleSavedObject>,
+  rulesToChange: readonly RuleSavedObject[]
+): Map<string, RuleSavedObject> => {
+  const changedRules = new Map(currentChangedRules);
+
+  rulesToChange.forEach((ruleToChange) => {
+    const baseRule = baseRules.get(ruleToChange.id);
+    const changedRule = changedRules.get(ruleToChange.id);
+
+    if (!baseRule) throw new Error('expected base rule to exists');
+
+    const baseRuleChanged = baseRule.attributes.enabled !== ruleToChange.attributes.enabled;
+
+    if (!changedRule && baseRuleChanged) changedRules.set(ruleToChange.id, ruleToChange);
+
+    if (changedRule && !baseRuleChanged) changedRules.delete(ruleToChange.id);
+  });
+
+  return changedRules;
+};
+
+const getLocalRulesResult = (
+  result: SimpleRulesQueryResult,
+  localData: readonly RuleSavedObject[]
+): LocalRulesResult => {
+  switch (result.status) {
+    case 'success':
+      return {
+        ...result,
+        data: localData,
+        total: result.data.total,
+      };
+    case 'error':
+      return {
+        ...result,
+        error: extractErrorMessage(result.error),
+      };
+    default:
+      return result;
+  }
+};
+
+export const RulesContainer = () => {
+  const [changedRules, setChangedRules] = useState<Map<string, RuleSavedObject>>(new Map());
+  const [selectedRules, setSelectedRules] = useState<RuleSavedObject[]>([]);
+  const [rulesQuery, setRulesQuery] = useState<RulesQuery>({ page: 1, perPage: 5, search: '' });
+
+  const { data, status, error, refetch } = useFindCspRules({
+    ...rulesQuery,
+    search: getSimpleQueryString(rulesQuery.search),
+    searchFields: ['name'],
+  });
+
+  const { mutate: bulkUpdate, isLoading: isUpdating } = useBulkUpdateCspRules();
+
+  const baseData: { rules: RuleSavedObject[]; rulesMap: Map<string, RuleSavedObject> } =
+    useMemo(() => {
+      const rules = data?.savedObjects || [];
+      return { rules, rulesMap: new Map(rules.map((rule) => [rule.id, rule])) };
+    }, [data]);
+
+  /**
+   * TODO(TS@4.6): remove casting
+   * @see https://github.com/microsoft/TypeScript/pull/46266
+   */
+  const localRulesResult = useMemo(
+    () =>
+      getLocalRulesResult(
+        { data, error, status } as SimpleRulesQueryResult,
+        baseData.rules.map((rule) => changedRules.get(rule.attributes.id) || rule)
+      ),
+    [baseData, changedRules, status, data, error]
+  );
+
+  const hasChanges = !!changedRules.size;
+
+  const toggleRules = (rules: RuleSavedObject[], enabled: boolean) =>
+    setChangedRules(
+      getChangedRules(
+        baseData.rulesMap,
+        changedRules,
+        rules.map((rule) => ({
+          ...rule,
+          attributes: { ...rule.attributes, enabled },
+        }))
+      )
+    );
+
+  const bulkToggleRules = (enabled: boolean) =>
+    toggleRules(
+      selectedRules.map((rule) => baseData.rulesMap.get(rule.id)!),
+      enabled
+    );
+
+  const toggleRule = (rule: RuleSavedObject) => toggleRules([rule], !rule.attributes.enabled);
+
+  const bulkUpdateRules = () => bulkUpdate([...changedRules].map(([, rule]) => rule.attributes));
+
+  const discardChanges = useCallback(() => setChangedRules(new Map()), []);
+
+  useEffect(discardChanges, [baseData, discardChanges]);
+
+  return (
+    <div data-test-subj={TEST_SUBJECTS.CSP_RULES_CONTAINER}>
+      <EuiPanel hasBorder hasShadow={false}>
+        <RulesTableHeader
+          search={(value) => setRulesQuery((currentQuery) => ({ ...currentQuery, search: value }))}
+          refresh={refetch}
+          bulkEnable={() => bulkToggleRules(true)}
+          bulkDisable={() => bulkToggleRules(false)}
+          selectedRulesCount={selectedRules.length}
+          searchValue={rulesQuery.search}
+          totalRulesCount={localRulesResult.status === 'success' ? localRulesResult.total : 0}
+          isSearching={localRulesResult.status === 'loading'}
+        />
+        <RulesTable
+          {...localRulesResult}
+          {...rulesQuery}
+          toggleRule={toggleRule}
+          setSelectedRules={setSelectedRules}
+          setPagination={(paginationQuery) =>
+            setRulesQuery((currentQuery) => ({ ...currentQuery, ...paginationQuery }))
+          }
+        />
+      </EuiPanel>
+      {!!hasChanges && (
+        <RulesBottomBar onSave={bulkUpdateRules} onCancel={discardChanges} isLoading={isUpdating} />
+      )}
+    </div>
+  );
+};
+
+type DistributivePick<T, K extends keyof T> = T extends unknown ? Pick<T, K> : never;

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table.tsx
@@ -15,7 +15,6 @@ import {
   EuiBasicTableProps,
 } from '@elastic/eui';
 // import moment from 'moment';
-import { extractErrorMessage } from '../../../common/utils/helpers';
 import type { RulesState, RuleSavedObject } from './rules_container';
 import * as TEST_SUBJECTS from './test_subjects';
 import * as TEXT from './translations';
@@ -68,7 +67,7 @@ export const RulesTable = ({
     <EuiBasicTable
       data-test-subj={TEST_SUBJECTS.CSP_RULES_TABLE}
       loading={props.status === 'loading'}
-      error={props.error ? extractErrorMessage(props.error) : undefined}
+      error={props.error || undefined}
       items={items}
       columns={columns}
       pagination={euiPagination}

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table.tsx
@@ -1,0 +1,137 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React, { useMemo } from 'react';
+import {
+  Criteria,
+  EuiLink,
+  EuiSwitch,
+  EuiTableFieldDataColumnType,
+  EuiEmptyPrompt,
+  EuiBasicTable,
+  EuiBasicTableProps,
+} from '@elastic/eui';
+import moment from 'moment';
+import { extractErrorMessage } from '../../../common/utils/helpers';
+import type { RulesState, RuleSavedObject } from './rules_container';
+import * as TEST_SUBJECTS from './test_subjects';
+import * as TEXT from './translations';
+
+type RulesTableProps = RulesState & {
+  toggleRule(rule: RuleSavedObject): void;
+  setSelectedRules(rules: RuleSavedObject[]): void;
+  setPagination(pagination: Pick<RulesState, 'perPage' | 'page'>): void;
+};
+
+export const RulesTable = ({
+  toggleRule,
+  setSelectedRules,
+  setPagination,
+  perPage,
+  page,
+  ...props
+}: RulesTableProps) => {
+  const columns = useMemo(() => getColumns({ toggleRule }), [toggleRule]);
+
+  const items = useMemo(
+    () => (props.status === 'success' ? props.data?.slice() || [] : []),
+    [props.data, props.status]
+  );
+
+  const euiPagination: EuiBasicTableProps<RuleSavedObject>['pagination'] = {
+    pageIndex: Math.max(page - 1, 0),
+    pageSize: perPage,
+    totalItemCount: props.status === 'success' ? props.total : 0,
+    pageSizeOptions: [1, 5, 10, 25],
+    hidePerPageOptions: false,
+  };
+
+  const selection: EuiBasicTableProps<RuleSavedObject>['selection'] = {
+    selectable: () => true,
+    onSelectionChange: setSelectedRules,
+  };
+
+  const onTableChange = ({ page: _page }: Criteria<RuleSavedObject>) => {
+    if (!_page) return;
+    setPagination({ page: _page.index + 1, perPage: _page.size });
+  };
+
+  // Show "zero state"
+  if (props.status === 'success' && !props.data)
+    // TODO: use our own logo
+    return <EuiEmptyPrompt iconType="logoKibana" title={<h2>{TEXT.MISSING_RULES}</h2>} />;
+
+  return (
+    <EuiBasicTable
+      data-test-subj={TEST_SUBJECTS.CSP_RULES_TABLE}
+      loading={props.status === 'loading'}
+      error={props.error ? extractErrorMessage(props.error) : undefined}
+      items={items}
+      columns={columns}
+      pagination={euiPagination}
+      onChange={onTableChange}
+      isSelectable={true}
+      selection={selection}
+      itemId={(v) => v.id}
+    />
+  );
+};
+
+const ruleNameRenderer = (name: string) => (
+  <EuiLink className="eui-textTruncate" title={name}>
+    {name}
+  </EuiLink>
+);
+
+const timestampRenderer = (timestamp: string) =>
+  moment.duration(moment().diff(timestamp)).humanize();
+
+interface GetColumnProps {
+  toggleRule: (rule: RuleSavedObject) => void;
+}
+
+const createRuleEnabledSwitchRenderer =
+  ({ toggleRule }: GetColumnProps) =>
+  (value: any, rule: RuleSavedObject) =>
+    (
+      <EuiSwitch
+        label=""
+        checked={value}
+        onChange={() => toggleRule(rule)}
+        data-test-subj={TEST_SUBJECTS.getCspRulesTableItemSwitchTestId(rule.attributes.id)}
+      />
+    );
+
+const getColumns = ({
+  toggleRule,
+}: GetColumnProps): Array<EuiTableFieldDataColumnType<RuleSavedObject>> => [
+  {
+    field: 'attributes.name',
+    name: TEXT.RULE_NAME,
+    width: '60%',
+    truncateText: true,
+    render: ruleNameRenderer,
+  },
+  {
+    field: 'section', // TODO: what field is this?
+    name: TEXT.SECTION,
+    width: '15%',
+  },
+  {
+    // TODO: get timestamp value
+    // add SavedObject["updated_at"] to SimpleSavedObject?
+    field: 'updated_at',
+    name: TEXT.UPDATED_AT,
+    width: '15%',
+    // render: timestampRenderer,
+  },
+  {
+    field: 'attributes.enabled',
+    name: TEXT.ENABLED,
+    render: createRuleEnabledSwitchRenderer({ toggleRule }),
+    width: '10%',
+  },
+];

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table.tsx
@@ -14,7 +14,7 @@ import {
   EuiBasicTable,
   EuiBasicTableProps,
 } from '@elastic/eui';
-import moment from 'moment';
+// import moment from 'moment';
 import { extractErrorMessage } from '../../../common/utils/helpers';
 import type { RulesState, RuleSavedObject } from './rules_container';
 import * as TEST_SUBJECTS from './test_subjects';
@@ -86,8 +86,8 @@ const ruleNameRenderer = (name: string) => (
   </EuiLink>
 );
 
-const timestampRenderer = (timestamp: string) =>
-  moment.duration(moment().diff(timestamp)).humanize();
+// const timestampRenderer = (timestamp: string) =>
+//   moment.duration(moment().diff(timestamp)).humanize();
 
 interface GetColumnProps {
   toggleRule: (rule: RuleSavedObject) => void;

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table_header.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table_header.tsx
@@ -4,36 +4,32 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import React, { useState } from 'react';
-import {
-  EuiContextMenuPanel,
-  EuiContextMenuItem,
-  EuiContextMenuItemProps,
-  EuiPopover,
-  EuiSpacer,
-  EuiFieldSearch,
-  useGeneratedHtmlId,
-  EuiButtonEmpty,
-  EuiFlexGroup,
-  EuiFlexItem,
-} from '@elastic/eui';
+import React from 'react';
+import { EuiSpacer, EuiFieldSearch, EuiButtonEmpty, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import * as TEST_SUBJECTS from './test_subjects';
 import * as TEXT from './translations';
-
-interface RulesBulkActionsMenuProps {
-  items: ReadonlyArray<EuiContextMenuItemProps & { text: string }>;
-}
+import { RulesBulkActionsMenu } from './rules_bulk_actions_menu';
 
 interface RulesTableToolbarProps {
   search(value: string): void;
   refresh(): void;
   bulkEnable(): void;
   bulkDisable(): void;
+  selectAll(): void;
+  clearSelection(): void;
   totalRulesCount: number;
   selectedRulesCount: number;
   searchValue: string;
   isSearching: boolean;
+}
+
+interface CounterProps {
+  count: number;
+}
+
+interface ButtonProps {
+  onClick(): void;
 }
 
 export const RulesTableHeader = ({
@@ -41,115 +37,168 @@ export const RulesTableHeader = ({
   refresh,
   bulkEnable,
   bulkDisable,
+  selectAll,
+  clearSelection,
   totalRulesCount,
   selectedRulesCount,
   searchValue,
   isSearching,
 }: RulesTableToolbarProps) => (
   <div>
-    <EuiFlexGroup alignItems="center" justifyContent="spaceBetween">
-      <EuiFlexItem
-        grow={false}
-        style={{ flexDirection: 'row', fontVariantNumeric: 'tabular-nums' }}
-      >
-        <FormattedMessage
-          id="xpack.csp.rules.total_rules_count"
-          defaultMessage="Showing {totalRulesCount} rules"
-          values={{
-            totalRulesCount: <b>&nbsp;{totalRulesCount}&nbsp;</b>,
-          }}
-        />
-        <span>&nbsp;&nbsp;|&nbsp;&nbsp;</span>
-        <FormattedMessage
-          id="xpack.csp.rules.selected_rules_count"
-          defaultMessage="Selected {selectedRulesCount} rules"
-          values={{
-            selectedRulesCount: <b>&nbsp;{selectedRulesCount}&nbsp;</b>,
-          }}
-        />
-      </EuiFlexItem>
-      <EuiFlexItem grow={false}>
-        <RulesBulkActionsMenu
-          items={[
-            {
-              icon: 'copy', // TODO: icon
-              text: TEXT.ENABLE,
-              'data-test-subj': TEST_SUBJECTS.CSP_RULES_TABLE_BULK_ENABLE_BUTTON,
-              onClick: bulkEnable,
-            },
-            {
-              icon: 'copy', // TODO: icon
-              text: TEXT.DISABLE,
-              'data-test-subj': TEST_SUBJECTS.CSP_RULES_TABLE_BULK_DISABLE_BUTTON,
-              onClick: bulkDisable,
-            },
-          ]}
-        />
-      </EuiFlexItem>
-      <EuiFlexItem grow={false}>
-        <EuiButtonEmpty
-          onClick={refresh}
-          iconType={'refresh'}
-          data-test-subj={TEST_SUBJECTS.CSP_RULES_TABLE_REFRESH_BUTTON}
-        >
-          {TEXT.REFRESH}
-        </EuiButtonEmpty>
-      </EuiFlexItem>
-      <EuiFlexItem grow={true} style={{ alignItems: 'flex-end' }}>
-        <EuiFieldSearch
-          isLoading={isSearching}
-          placeholder={TEXT.SEARCH}
-          value={searchValue}
-          onChange={(e) => search(e.target.value)}
-        />
-      </EuiFlexItem>
+    <EuiFlexGroup alignItems="center" justifyContent="spaceBetween" responsive={false} wrap>
+      <Counters total={totalRulesCount} selected={selectedRulesCount} />
+      <SelectAllToggle
+        isSelectAll={selectedRulesCount === totalRulesCount}
+        clear={clearSelection}
+        select={selectAll}
+      />
+      <BulkMenu
+        bulkEnable={bulkEnable}
+        bulkDisable={bulkDisable}
+        selectedRulesCount={selectedRulesCount}
+      />
+      <RefreshButton onClick={refresh} />
+      <SearchField isSearching={isSearching} searchValue={searchValue} search={search} />
     </EuiFlexGroup>
     <EuiSpacer />
   </div>
 );
 
-const RulesBulkActionsMenu = ({ items }: RulesBulkActionsMenuProps) => {
-  const [isPopoverOpen, setPopover] = useState(false);
-  const smallContextMenuPopoverId = useGeneratedHtmlId({
-    prefix: 'smallContextMenuPopover',
-  });
+const Counters = ({ total, selected }: { total: number; selected: number }) => (
+  <EuiFlexItem grow={false} style={{ flexDirection: 'row', fontVariantNumeric: 'tabular-nums' }}>
+    <TotalRulesCount count={total} />
+    {Spacer}
+    <SelectedRulesCount count={selected} />
+  </EuiFlexItem>
+);
 
-  const onButtonClick = () => setPopover(!isPopoverOpen);
+const SelectAllToggle = ({
+  isSelectAll,
+  select,
+  clear,
+}: {
+  select(): void;
+  clear(): void;
+  isSelectAll: boolean;
+}) => (
+  <EuiFlexItem grow={false}>
+    {isSelectAll ? <ClearSelectionButton onClick={clear} /> : <SelectAllButton onClick={select} />}
+  </EuiFlexItem>
+);
 
-  const closePopover = () => setPopover(false);
-
-  const data = items.map((item) => (
-    <EuiContextMenuItem
-      {...item}
-      key={item.text}
-      children={item.text}
-      onClick={(e) => {
-        closePopover();
-        item.onClick?.(e);
-      }}
+const BulkMenu = ({
+  bulkEnable,
+  bulkDisable,
+  selectedRulesCount,
+}: Pick<RulesTableToolbarProps, 'bulkDisable' | 'bulkEnable' | 'selectedRulesCount'>) => (
+  <EuiFlexItem grow={false}>
+    <RulesBulkActionsMenu
+      items={[
+        {
+          icon: 'copy', // TODO: icon
+          disabled: !selectedRulesCount,
+          text: <ActivateRulesMenuItemText count={selectedRulesCount} />,
+          'data-test-subj': TEST_SUBJECTS.CSP_RULES_TABLE_BULK_ENABLE_BUTTON,
+          onClick: bulkEnable,
+        },
+        {
+          icon: 'copy', // TODO: icon
+          disabled: !selectedRulesCount,
+          text: <DeactivateRulesMenuItemText count={selectedRulesCount} />,
+          'data-test-subj': TEST_SUBJECTS.CSP_RULES_TABLE_BULK_DISABLE_BUTTON,
+          onClick: bulkDisable,
+        },
+      ]}
     />
-  ));
+  </EuiFlexItem>
+);
 
-  const button = (
+const SearchField = ({
+  search,
+  isSearching,
+  searchValue,
+}: Pick<RulesTableToolbarProps, 'isSearching' | 'searchValue' | 'search'>) => (
+  <EuiFlexItem grow={true} style={{ alignItems: 'flex-end' }}>
+    <EuiFieldSearch
+      isLoading={isSearching}
+      placeholder={TEXT.SEARCH}
+      value={searchValue}
+      onChange={(e) => search(e.target.value)}
+      style={{ minWidth: 150 }}
+    />
+  </EuiFlexItem>
+);
+
+const TotalRulesCount = ({ count }: CounterProps) => (
+  <FormattedMessage
+    id="xpack.csp.rules.header.totalRulesCount"
+    defaultMessage="Showing {rules}"
+    values={{ rules: <RulesCount count={count} /> }}
+  />
+);
+
+const SelectedRulesCount = ({ count }: CounterProps) => (
+  <FormattedMessage
+    id="xpack.csp.rules.header.selectedRulesCount"
+    defaultMessage="Selected {rules}"
+    values={{ rules: <RulesCount count={count} /> }}
+  />
+);
+
+const ActivateRulesMenuItemText = ({ count }: CounterProps) => (
+  <FormattedMessage
+    id="xpack.csp.rules.activate_all"
+    defaultMessage="Activate {rules}"
+    values={{ rules: <RulesCount count={count} /> }}
+  />
+);
+
+const DeactivateRulesMenuItemText = ({ count }: CounterProps) => (
+  <FormattedMessage
+    id="xpack.csp.rules.deactivate_all"
+    defaultMessage="Deactivate {rules}"
+    values={{ rules: <RulesCount count={count} /> }}
+  />
+);
+
+const RulesCount = ({ count }: CounterProps) => (
+  <FormattedMessage
+    id="xpack.csp.rules.header.rules_count"
+    defaultMessage="{count, plural, one {# rule} other {# rules}}"
+    values={{ count }}
+  />
+);
+
+const ClearSelectionButton = ({ onClick }: ButtonProps) => (
+  <EuiButtonEmpty
+    onClick={onClick}
+    iconType={'cross'}
+    data-test-subj={TEST_SUBJECTS.CSP_RULES_TABLE_CLEAR_SELECTION_BUTTON}
+  >
+    <FormattedMessage id="xpack.csp.rules.clear_selection" defaultMessage="Clear Selection" />
+  </EuiButtonEmpty>
+);
+
+const SelectAllButton = ({ onClick }: ButtonProps) => (
+  <EuiButtonEmpty
+    onClick={onClick}
+    iconType={'pagesSelect'}
+    data-test-subj={TEST_SUBJECTS.CSP_RULES_TABLE_SELECT_ALL_BUTTON}
+  >
+    <FormattedMessage id="xpack.csp.rules.select_all" defaultMessage="Select All" />
+  </EuiButtonEmpty>
+);
+
+const RefreshButton = ({ onClick }: ButtonProps) => (
+  <EuiFlexItem grow={false}>
     <EuiButtonEmpty
-      iconType={'arrowDown'}
-      onClick={onButtonClick}
-      data-test-subj={TEST_SUBJECTS.CSP_RULES_TABLE_BULK_MENU_BUTTON}
+      onClick={onClick}
+      iconType={'refresh'}
+      data-test-subj={TEST_SUBJECTS.CSP_RULES_TABLE_REFRESH_BUTTON}
     >
-      {TEXT.BULK_ACTIONS}
+      {TEXT.REFRESH}
     </EuiButtonEmpty>
-  );
+  </EuiFlexItem>
+);
 
-  return (
-    <EuiPopover
-      id={smallContextMenuPopoverId}
-      button={button}
-      isOpen={isPopoverOpen}
-      closePopover={closePopover}
-      panelPaddingSize="none"
-      anchorPosition="downLeft"
-    >
-      <EuiContextMenuPanel size="s" items={data} />
-    </EuiPopover>
-  );
-};
+const Spacer = <span>&nbsp;&nbsp;|&nbsp;&nbsp;</span>;

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table_header.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table_header.tsx
@@ -1,0 +1,138 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React, { useState } from 'react';
+import {
+  EuiContextMenuPanel,
+  EuiContextMenuItem,
+  EuiContextMenuItemProps,
+  EuiPopover,
+  EuiSpacer,
+  EuiFieldSearch,
+  useGeneratedHtmlId,
+  EuiButtonEmpty,
+  EuiFlexGroup,
+  EuiFlexItem,
+} from '@elastic/eui';
+import * as TEST_SUBJECTS from './test_subjects';
+import * as TEXT from './translations';
+
+interface RulesBulkActionsMenuProps {
+  items: ReadonlyArray<EuiContextMenuItemProps & { text: string }>;
+}
+
+interface RuelsTableToolbarProps {
+  search(value: string): void;
+  refresh(): void;
+  bulkEnable(): void;
+  bulkDisable(): void;
+  selectedRulesCount: number;
+  searchValue: string;
+  isSearching: boolean;
+}
+
+export const RulesTableHeader = ({
+  search,
+  refresh,
+  bulkEnable,
+  bulkDisable,
+  selectedRulesCount,
+  searchValue,
+  isSearching,
+}: RuelsTableToolbarProps) => (
+  <div>
+    <EuiFlexGroup alignItems="center" justifyContent="spaceBetween">
+      <EuiFlexItem grow={true}>
+        <span>
+          Selected <strong>{selectedRulesCount}</strong> rules
+        </span>
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <RulesBulkActionsMenu
+          items={[
+            {
+              icon: 'copy', // TODO: icon
+              text: TEXT.ENABLE, // TODO: i18n
+              'data-test-subj': TEST_SUBJECTS.CSP_RULES_TABLE_BULK_ENABLE_BUTTON,
+              onClick: bulkEnable,
+            },
+            {
+              icon: 'copy', // TODO: icon
+              text: TEXT.DISABLE, // TODO: i18n
+              'data-test-subj': TEST_SUBJECTS.CSP_RULES_TABLE_BULK_DISABLE_BUTTON,
+              onClick: bulkDisable,
+            },
+          ]}
+        />
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiButtonEmpty
+          onClick={refresh}
+          iconType={'refresh'}
+          data-test-subj={TEST_SUBJECTS.CSP_RULES_TABLE_REFRESH_BUTTON}
+        >
+          {TEXT.REFRESH}
+        </EuiButtonEmpty>
+      </EuiFlexItem>
+      <EuiFlexItem grow={true}>
+        <EuiFieldSearch
+          isLoading={isSearching}
+          placeholder={TEXT.SEARCH}
+          value={searchValue}
+          onChange={(e) => search(e.target.value)}
+        />
+      </EuiFlexItem>
+    </EuiFlexGroup>
+    <EuiSpacer />
+  </div>
+);
+
+const RulesBulkActionsMenu = ({ items }: RulesBulkActionsMenuProps) => {
+  const [isPopoverOpen, setPopover] = useState(false);
+  const smallContextMenuPopoverId = useGeneratedHtmlId({
+    prefix: 'smallContextMenuPopover',
+  });
+
+  const onButtonClick = () => setPopover(!isPopoverOpen);
+
+  const closePopover = () => setPopover(false);
+
+  const data = items.map((item) => (
+    <EuiContextMenuItem
+      {...item}
+      key={item.text}
+      children={item.text}
+      onClick={(e) => {
+        closePopover();
+        item.onClick?.(e);
+      }}
+    />
+  ));
+
+  // TODO: i18n
+  const button = (
+    <EuiButtonEmpty
+      iconType={'arrowDown'}
+      onClick={onButtonClick}
+      data-test-subj={TEST_SUBJECTS.CSP_RULES_TABLE_BULK_MENU_BUTTON}
+    >
+      {TEXT.BULK_ACTIONS}
+    </EuiButtonEmpty>
+  );
+
+  return (
+    <EuiPopover
+      id={smallContextMenuPopoverId}
+      button={button}
+      isOpen={isPopoverOpen}
+      closePopover={closePopover}
+      panelPaddingSize="none"
+      anchorPosition="downLeft"
+    >
+      <EuiContextMenuPanel size="s" items={data} />
+    </EuiPopover>
+  );
+};

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table_header.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table_header.tsx
@@ -17,6 +17,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
 } from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n-react';
 import * as TEST_SUBJECTS from './test_subjects';
 import * as TEXT from './translations';
 
@@ -24,11 +25,12 @@ interface RulesBulkActionsMenuProps {
   items: ReadonlyArray<EuiContextMenuItemProps & { text: string }>;
 }
 
-interface RuelsTableToolbarProps {
+interface RulesTableToolbarProps {
   search(value: string): void;
   refresh(): void;
   bulkEnable(): void;
   bulkDisable(): void;
+  totalRulesCount: number;
   selectedRulesCount: number;
   searchValue: string;
   isSearching: boolean;
@@ -39,29 +41,45 @@ export const RulesTableHeader = ({
   refresh,
   bulkEnable,
   bulkDisable,
+  totalRulesCount,
   selectedRulesCount,
   searchValue,
   isSearching,
-}: RuelsTableToolbarProps) => (
+}: RulesTableToolbarProps) => (
   <div>
     <EuiFlexGroup alignItems="center" justifyContent="spaceBetween">
-      <EuiFlexItem grow={true}>
-        <span>
-          Selected <strong>{selectedRulesCount}</strong> rules
-        </span>
+      <EuiFlexItem
+        grow={false}
+        style={{ flexDirection: 'row', fontVariantNumeric: 'tabular-nums' }}
+      >
+        <FormattedMessage
+          id="xpack.csp.rules.total_rules_count"
+          defaultMessage="Showing {totalRulesCount} rules"
+          values={{
+            totalRulesCount: <b>&nbsp;{totalRulesCount}&nbsp;</b>,
+          }}
+        />
+        <span>&nbsp;&nbsp;|&nbsp;&nbsp;</span>
+        <FormattedMessage
+          id="xpack.csp.rules.selected_rules_count"
+          defaultMessage="Selected {selectedRulesCount} rules"
+          values={{
+            selectedRulesCount: <b>&nbsp;{selectedRulesCount}&nbsp;</b>,
+          }}
+        />
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
         <RulesBulkActionsMenu
           items={[
             {
               icon: 'copy', // TODO: icon
-              text: TEXT.ENABLE, // TODO: i18n
+              text: TEXT.ENABLE,
               'data-test-subj': TEST_SUBJECTS.CSP_RULES_TABLE_BULK_ENABLE_BUTTON,
               onClick: bulkEnable,
             },
             {
               icon: 'copy', // TODO: icon
-              text: TEXT.DISABLE, // TODO: i18n
+              text: TEXT.DISABLE,
               'data-test-subj': TEST_SUBJECTS.CSP_RULES_TABLE_BULK_DISABLE_BUTTON,
               onClick: bulkDisable,
             },
@@ -77,7 +95,7 @@ export const RulesTableHeader = ({
           {TEXT.REFRESH}
         </EuiButtonEmpty>
       </EuiFlexItem>
-      <EuiFlexItem grow={true}>
+      <EuiFlexItem grow={true} style={{ alignItems: 'flex-end' }}>
         <EuiFieldSearch
           isLoading={isSearching}
           placeholder={TEXT.SEARCH}
@@ -112,7 +130,6 @@ const RulesBulkActionsMenu = ({ items }: RulesBulkActionsMenuProps) => {
     />
   ));
 
-  // TODO: i18n
   const button = (
     <EuiButtonEmpty
       iconType={'arrowDown'}

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/test_subjects.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/test_subjects.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const CSP_RULES_CONTAINER = 'csp_rules_container';
+export const CSP_RULES_TABLE_ITEM_SWITCH = 'csp_rules_table_item_switch';
+export const CSP_RULES_SAVE_BUTTON = 'csp_rules_table_save_button';
+export const CSP_RULES_TABLE = 'csp_rules_table';
+export const CSP_RULES_TABLE_BULK_MENU_BUTTON = 'csp_rules_table_bulk_menu_button';
+export const CSP_RULES_TABLE_BULK_ENABLE_BUTTON = 'csp_rules_table_bulk_enable_button';
+export const CSP_RULES_TABLE_BULK_DISABLE_BUTTON = 'csp_rules_table_bulk_disable_button';
+export const CSP_RULES_TABLE_REFRESH_BUTTON = 'csp_rules_table_refresh_button';
+
+export const getCspRulesTableItemSwitchTestId = (id: string) =>
+  `${CSP_RULES_TABLE_ITEM_SWITCH}_${id}`;

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/test_subjects.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/test_subjects.ts
@@ -13,6 +13,8 @@ export const CSP_RULES_TABLE_BULK_MENU_BUTTON = 'csp_rules_table_bulk_menu_butto
 export const CSP_RULES_TABLE_BULK_ENABLE_BUTTON = 'csp_rules_table_bulk_enable_button';
 export const CSP_RULES_TABLE_BULK_DISABLE_BUTTON = 'csp_rules_table_bulk_disable_button';
 export const CSP_RULES_TABLE_REFRESH_BUTTON = 'csp_rules_table_refresh_button';
+export const CSP_RULES_TABLE_SELECT_ALL_BUTTON = 'rules_select_all';
+export const CSP_RULES_TABLE_CLEAR_SELECTION_BUTTON = 'rules_clear_selection';
 
 export const getCspRulesTableItemSwitchTestId = (id: string) =>
   `${CSP_RULES_TABLE_ITEM_SWITCH}_${id}`;

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/translations.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/translations.ts
@@ -19,14 +19,6 @@ export const UNKNOWN_ERROR = i18n.translate('xpack.csp.unknown_erro', {
   defaultMessage: 'Unknown Error',
 });
 
-export const ENABLE = i18n.translate('xpack.csp.enable', {
-  defaultMessage: 'Enable',
-});
-
-export const DISABLE = i18n.translate('xpack.csp.disable', {
-  defaultMessage: 'Disable',
-});
-
 export const REFRESH = i18n.translate('xpack.csp.refresh', {
   defaultMessage: 'Refresh',
 });

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/translations.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/translations.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+
+export const SAVE = i18n.translate('xpack.csp.save', {
+  defaultMessage: 'Save',
+});
+
+export const CANCEL = i18n.translate('xpack.csp.cancel', {
+  defaultMessage: 'Cancel',
+});
+
+export const UNKNOWN_ERROR = i18n.translate('xpack.csp.unknown_erro', {
+  defaultMessage: 'Unknown Error',
+});
+
+export const ENABLE = i18n.translate('xpack.csp.enable', {
+  defaultMessage: 'Enable',
+});
+
+export const DISABLE = i18n.translate('xpack.csp.disable', {
+  defaultMessage: 'Disable',
+});
+
+export const REFRESH = i18n.translate('xpack.csp.refresh', {
+  defaultMessage: 'Refresh',
+});
+
+export const SEARCH = i18n.translate('xpack.csp.search', {
+  defaultMessage: 'Search',
+});
+
+export const BULK_ACTIONS = i18n.translate('xpack.csp.bulk_actions', {
+  defaultMessage: 'Bulk Actions',
+});
+
+export const RULE_NAME = i18n.translate('xpack.csp.rule_name', {
+  defaultMessage: 'Rule Name',
+});
+
+export const SECTION = i18n.translate('xpack.csp.section', {
+  defaultMessage: 'Section',
+});
+
+export const UPDATED_AT = i18n.translate('xpack.csp.updated_at', {
+  defaultMessage: 'Updated at',
+});
+
+export const ENABLED = i18n.translate('xpack.csp.enabled', {
+  defaultMessage: 'Enabled',
+});
+
+export const MISSING_RULES = i18n.translate('xpack.csp.missing_rules', {
+  defaultMessage: 'Rules are missing',
+});

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/use_csp_rules.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/use_csp_rules.ts
@@ -6,29 +6,23 @@
  */
 import { useQuery, useMutation, useQueryClient } from 'react-query';
 import { cspRuleAssetSavedObjectType, type CspRuleSchema } from '../../../common/schemas/csp_rule';
-import type { SavedObjectsFindOptions } from '../../../../../../src/core/public';
+import type { SavedObject, SavedObjectsFindOptions } from '../../../../../../src/core/public';
 import { useKibana } from '../../common/hooks/use_kibana';
 
-export type UseCspRulesOptions = Pick<
-  SavedObjectsFindOptions,
-  'search' | 'searchFields' | 'page' | 'perPage'
->;
+export type RuleSavedObject = SavedObject<CspRuleSchema>; // SimpleSavedObject
+export type RulesQuery = Required<Pick<SavedObjectsFindOptions, 'search' | 'page' | 'perPage'>>;
+export type RulesQueryResult = ReturnType<typeof useFindCspRules>;
 
-export const useFindCspRules = ({
-  search,
-  searchFields,
-  page = 1,
-  perPage = 10,
-}: UseCspRulesOptions) => {
+export const useFindCspRules = ({ search, page, perPage }: RulesQuery) => {
   const { savedObjects } = useKibana().services;
   return useQuery(
-    [cspRuleAssetSavedObjectType, { search, searchFields, page, perPage }],
+    [cspRuleAssetSavedObjectType, { search, page, perPage }],
     () =>
       savedObjects.client.find<CspRuleSchema>({
         type: cspRuleAssetSavedObjectType,
         search,
-        searchFields,
-        page,
+        searchFields: ['name'],
+        page: 1,
         // NOTE: 'name.raw' is a field mapping we defined on 'name' so it'd also be sortable
         // TODO: this needs to be shared or removed
         sortField: 'name.raw',
@@ -39,7 +33,7 @@ export const useFindCspRules = ({
 };
 
 export const useBulkUpdateCspRules = () => {
-  const { savedObjects } = useKibana().services;
+  const { savedObjects, notifications } = useKibana().services;
   const queryClient = useQueryClient();
 
   return useMutation(
@@ -52,7 +46,12 @@ export const useBulkUpdateCspRules = () => {
         }))
       ),
     {
+      onError: (err) => {
+        if (err instanceof Error) notifications.toasts.addError(err, { title: 'Update Failed' });
+        else notifications.toasts.addDanger('Update Failed');
+      },
       onSettled: () =>
+        // Invalidate all queries for simplicity
         queryClient.invalidateQueries({
           queryKey: cspRuleAssetSavedObjectType,
           exact: false,

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/use_csp_rules.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/use_csp_rules.ts
@@ -6,10 +6,7 @@
  */
 import { useQuery, useMutation, useQueryClient } from 'react-query';
 import { cspRuleAssetSavedObjectType, type CspRuleSchema } from '../../../common/schemas/csp_rule';
-import type {
-  SavedObjectsBatchResponse,
-  SavedObjectsFindOptions,
-} from '../../../../../../src/core/public';
+import type { SavedObjectsFindOptions } from '../../../../../../src/core/public';
 import { useKibana } from '../../common/hooks/use_kibana';
 
 export type UseCspRulesOptions = Pick<
@@ -32,7 +29,7 @@ export const useFindCspRules = ({
         search,
         searchFields,
         page,
-        // NOTE: 'name.raw' is a field maping we defined on 'name' so it'd also be sortable
+        // NOTE: 'name.raw' is a field mapping we defined on 'name' so it'd also be sortable
         // TODO: this needs to be shared or removed
         sortField: 'name.raw',
         perPage,
@@ -47,14 +44,13 @@ export const useBulkUpdateCspRules = () => {
 
   return useMutation(
     (rules: CspRuleSchema[]) =>
-      savedObjects.client.bulkUpdate(
+      savedObjects.client.bulkUpdate<CspRuleSchema>(
         rules.map((rule) => ({
           type: cspRuleAssetSavedObjectType,
           id: rule.id,
           attributes: rule,
         }))
-        // TODO: fix bulkUpdate types in core
-      ) as Promise<SavedObjectsBatchResponse<CspRuleSchema>>,
+      ),
     {
       onSettled: () =>
         queryClient.invalidateQueries({

--- a/x-pack/plugins/cloud_security_posture/server/saved_objects/cis_1_4_1/rules.ts
+++ b/x-pack/plugins/cloud_security_posture/server/saved_objects/cis_1_4_1/rules.ts
@@ -8,9 +8,6 @@
 import type { SavedObjectsBulkCreateObject } from 'src/core/server';
 import type { CspRuleSchema } from '../../../common/schemas/csp_rule';
 import { cspRuleAssetSavedObjectType } from '../../../common/schemas/csp_rule';
-import Chance from 'chance';
-
-const chance = new Chance();
 
 const benchmark = { name: 'CIS', version: '1.4.1' } as const;
 
@@ -46,19 +43,6 @@ const RULES: CspRuleSchema[] = [
     muted: false,
     benchmark,
   },
-  ...Array.from({ length: 20 }, (x, i) => ({
-    id: chance.word(),
-    name: chance.sentence(),
-    description: chance.sentence(),
-    rationale: chance.sentence(),
-    impact: chance.sentence(),
-    default_value: chance.sentence(),
-    remediation: chance.sentence(),
-    tags: [],
-    enabled: true,
-    muted: false,
-    benchmark,
-  })),
 ];
 
 export const CIS_BENCHMARK_1_4_1_RULES: Array<SavedObjectsBulkCreateObject<CspRuleSchema>> =

--- a/x-pack/plugins/cloud_security_posture/server/saved_objects/cis_1_4_1/rules.ts
+++ b/x-pack/plugins/cloud_security_posture/server/saved_objects/cis_1_4_1/rules.ts
@@ -8,6 +8,9 @@
 import type { SavedObjectsBulkCreateObject } from 'src/core/server';
 import type { CspRuleSchema } from '../../../common/schemas/csp_rule';
 import { cspRuleAssetSavedObjectType } from '../../../common/schemas/csp_rule';
+import Chance from 'chance';
+
+const chance = new Chance();
 
 const benchmark = { name: 'CIS', version: '1.4.1' } as const;
 
@@ -43,6 +46,19 @@ const RULES: CspRuleSchema[] = [
     muted: false,
     benchmark,
   },
+  ...Array.from({ length: 20 }, (x, i) => ({
+    id: chance.word(),
+    name: chance.sentence(),
+    description: chance.sentence(),
+    rationale: chance.sentence(),
+    impact: chance.sentence(),
+    default_value: chance.sentence(),
+    remediation: chance.sentence(),
+    tags: [],
+    enabled: true,
+    muted: false,
+    benchmark,
+  })),
 ];
 
 export const CIS_BENCHMARK_1_4_1_RULES: Array<SavedObjectsBulkCreateObject<CspRuleSchema>> =


### PR DESCRIPTION
this PR builds on #121 and takes into account the issue below:
 - https://github.com/elastic/security-team/issues/3030


notable changes: 

- `useCspFindRules` now returns the full response instead of a paginated one. this is because when we bulk-change "select all" we need to have the data beforehand. UI is still paginated.  this is mainly because the api uses `PUT`. there may be a way to `PATCH` it but requires further exploration. 