### PR TITLE
create latest findings index

### DIFF
--- a/x-pack/plugins/cloud_security_posture/common/constants.ts
+++ b/x-pack/plugins/cloud_security_posture/common/constants.ts
@@ -11,6 +11,8 @@ export const BENCHMARKS_ROUTE_PATH = '/api/csp/benchmarks';
 
 export const CSP_KUBEBEAT_INDEX_PATTERN = 'logs-k8s_cis*';
 export const AGENT_LOGS_INDEX_PATTERN = '.logs-k8s_cis.metadata*';
+export const LATEST_FINDINGS_INDEX_PATTERN = '.csp-findings-latest';
+
 export const CSP_FINDINGS_INDEX_NAME = 'findings';
 export const CIS_KUBERNETES_PACKAGE_NAME = 'cis_kubernetes_benchmark';
 

--- a/x-pack/plugins/cloud_security_posture/server/create_latest_index.ts
+++ b/x-pack/plugins/cloud_security_posture/server/create_latest_index.ts
@@ -8,6 +8,7 @@ import { transformError } from '@kbn/securitysolution-es-utils';
 import type { ElasticsearchClient, Logger } from '../../../../src/core/server';
 import { LATEST_FINDINGS_INDEX_PATTERN } from '../common/constants';
 
+// TODO: Add integration tests
 export const initializeCspLatestFindingsIndex = async (
   esClient: ElasticsearchClient,
   logger: Logger

--- a/x-pack/plugins/cloud_security_posture/server/create_latest_index.ts
+++ b/x-pack/plugins/cloud_security_posture/server/create_latest_index.ts
@@ -4,7 +4,6 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-
 import { transformError } from '@kbn/securitysolution-es-utils';
 import type { ElasticsearchClient, Logger } from '../../../../src/core/server';
 import { LATEST_FINDINGS_INDEX_PATTERN } from '../common/constants';
@@ -20,16 +19,8 @@ export const initializeCspLatestFindingsIndex = async (
       await esClient.indices.create({
         index: LATEST_FINDINGS_INDEX_PATTERN,
         settings: {
-          //   is_write_index: true,
           hidden: true,
         },
-        // op_type: 'create',
-        // aliases: {
-        //   '.csp-findings-latest': {
-        //     is_write_index: true,
-        //     is_hidden: true,
-        //   },
-        // },
       });
     }
   } catch (err) {
@@ -38,17 +29,3 @@ export const initializeCspLatestFindingsIndex = async (
     logger.error(error.message);
   }
 };
-
-// async createInitialIndexIfNotExists(): Promise<void> {
-//     const exists = await this.esContext.esAdapter.doesAliasExist(this.esContext.esNames.alias);
-//     if (!exists) {
-//       await this.esContext.esAdapter.createIndex(this.esContext.esNames.initialIndex, {
-//         aliases: {
-//           [this.esContext.esNames.alias]: {
-//             is_write_index: true,
-//             is_hidden: true,
-//           },
-//         },
-//       });
-//     }
-//   }

--- a/x-pack/plugins/cloud_security_posture/server/create_latest_index.ts
+++ b/x-pack/plugins/cloud_security_posture/server/create_latest_index.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { transformError } from '@kbn/securitysolution-es-utils';
+import type { ElasticsearchClient, Logger } from '../../../../src/core/server';
+import { LATEST_FINDINGS_INDEX_PATTERN } from '../common/constants';
+
+export const initializeCspLatestFindingsIndex = async (
+  esClient: ElasticsearchClient,
+  logger: Logger
+) => {
+  try {
+    const isExists = await esClient.indices.existsAlias({ name: LATEST_FINDINGS_INDEX_PATTERN });
+
+    if (!isExists.body) {
+      await esClient.indices.create({
+        index: LATEST_FINDINGS_INDEX_PATTERN,
+        settings: {
+          //   is_write_index: true,
+          hidden: true,
+        },
+        // op_type: 'create',
+        // aliases: {
+        //   '.csp-findings-latest': {
+        //     is_write_index: true,
+        //     is_hidden: true,
+        //   },
+        // },
+      });
+    }
+  } catch (err) {
+    const error = transformError(err);
+    logger.error(`Failed to create ${LATEST_FINDINGS_INDEX_PATTERN}`);
+    logger.error(error.message);
+  }
+};
+
+// async createInitialIndexIfNotExists(): Promise<void> {
+//     const exists = await this.esContext.esAdapter.doesAliasExist(this.esContext.esNames.alias);
+//     if (!exists) {
+//       await this.esContext.esAdapter.createIndex(this.esContext.esNames.initialIndex, {
+//         aliases: {
+//           [this.esContext.esNames.alias]: {
+//             is_write_index: true,
+//             is_hidden: true,
+//           },
+//         },
+//       });
+//     }
+//   }

--- a/x-pack/plugins/cloud_security_posture/server/create_latest_index.ts
+++ b/x-pack/plugins/cloud_security_posture/server/create_latest_index.ts
@@ -14,7 +14,7 @@ export const initializeCspLatestFindingsIndex = async (
   logger: Logger
 ) => {
   try {
-    const isExists = await esClient.indices.existsAlias({ name: LATEST_FINDINGS_INDEX_PATTERN });
+    const isExists = await esClient.indices.exists({ index: LATEST_FINDINGS_INDEX_PATTERN });
 
     if (!isExists.body) {
       await esClient.indices.create({

--- a/x-pack/plugins/cloud_security_posture/server/plugin.ts
+++ b/x-pack/plugins/cloud_security_posture/server/plugin.ts
@@ -68,10 +68,7 @@ export class CspPlugin
     return {};
   }
 
-  public async start(
-    core: CoreStart,
-    plugins: CspServerPluginStartDeps
-  ): Promise<CspServerPluginStart> {
+  public start(core: CoreStart, plugins: CspServerPluginStartDeps): CspServerPluginStart {
     this.logger.debug('csp: Started');
     this.CspAppService.start({
       ...plugins.fleet,

--- a/x-pack/plugins/cloud_security_posture/server/plugin.ts
+++ b/x-pack/plugins/cloud_security_posture/server/plugin.ts
@@ -79,18 +79,6 @@ export class CspPlugin
     initializeCspRules(core.savedObjects.createInternalRepository());
     initializeCspLatestFindingsIndex(core.elasticsearch.client.asInternalUser, this.logger);
 
-    const indexExists = await core.elasticsearch.client.asInternalUser.indices.exists({
-      index: 'csp-latest-findings',
-    });
-    if (!indexExists) {
-      core.elasticsearch.client.asInternalUser.index({
-        id: 'csp-latest-findings',
-        index: '.csp-findings-latest',
-        op_type: 'create',
-        body: {},
-      });
-    }
-
     return {};
   }
   public stop() {}


### PR DESCRIPTION
When adding score Transform via integration assets, it's expected to find the latest finding index. 
This PR creates a hidden index to serve the score Transform

Follow setup [instructions](https://github.com/elastic/security-team/issues/2758#issuecomment-1054479406).