### PR TITLE
convert run_id to cycle_id

### DIFF
--- a/x-pack/plugins/cloud_security_posture/server/routes/findings/findings.test.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/findings/findings.test.ts
@@ -162,7 +162,7 @@ describe('findings API', () => {
                 {
                   group_docs: {
                     hits: {
-                      hits: [{ fields: { 'run_id.keyword': ['randomId1'] } }],
+                      hits: [{ fields: { 'cycle_id.keyword': ['randomId1'] } }],
                     },
                   },
                 },
@@ -183,7 +183,7 @@ describe('findings API', () => {
       expect(handlerArgs).toMatchObject({
         query: {
           bool: {
-            filter: [{ term: { 'run_id.keyword': 'randomId1' } }],
+            filter: [{ term: { 'cycle_id.keyword': 'randomId1' } }],
           },
         },
       });

--- a/x-pack/plugins/cloud_security_posture/server/routes/findings/findings.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/findings/findings.ts
@@ -54,7 +54,7 @@ const buildQueryRequest = (latestCycleIds?: string[]): QueryDslQueryContainer =>
   let filterPart: QueryDslQueryContainer = { match_all: {} };
   if (!!latestCycleIds) {
     const filter = latestCycleIds.map((latestCycleId) => ({
-      term: { 'run_id.keyword': latestCycleId },
+      term: { 'cycle_id.keyword': latestCycleId },
     }));
     filterPart = { bool: { filter } };
   }

--- a/x-pack/plugins/cloud_security_posture/server/routes/findings/get_latest_cycle.test.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/findings/get_latest_cycle.test.ts
@@ -47,7 +47,7 @@ describe('get latest cycle ids', () => {
               {
                 group_docs: {
                   hits: {
-                    hits: [{ fields: { 'run_id.keyword': ['randomId1'] } }],
+                    hits: [{ fields: { 'cycle_id.keyword': ['randomId1'] } }],
                   },
                 },
               },
@@ -70,21 +70,21 @@ describe('get latest cycle ids', () => {
               {
                 group_docs: {
                   hits: {
-                    hits: [{ fields: { 'run_id.keyword': ['randomId1'] } }],
+                    hits: [{ fields: { 'cycle_id.keyword': ['randomId1'] } }],
                   },
                 },
               },
               {
                 group_docs: {
                   hits: {
-                    hits: [{ fields: { 'run_id.keyword': ['randomId2'] } }],
+                    hits: [{ fields: { 'cycle_id.keyword': ['randomId2'] } }],
                   },
                 },
               },
               {
                 group_docs: {
                   hits: {
-                    hits: [{ fields: { 'run_id.keyword': ['randomId3'] } }],
+                    hits: [{ fields: { 'cycle_id.keyword': ['randomId3'] } }],
                   },
                 },
               },

--- a/x-pack/plugins/cloud_security_posture/server/routes/findings/get_latest_cycle_ids.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/findings/get_latest_cycle_ids.ts
@@ -30,11 +30,11 @@ const getAgentLogsEsQuery = (): SearchRequest => ({
       },
     },
   },
-  fields: ['run_id.keyword', 'agent.id.keyword'],
+  fields: ['cycle_id.keyword', 'agent.id.keyword'],
   _source: false,
 });
 
-const getCycleId = (v: any): string => v.group_docs.hits.hits?.[0]?.fields['run_id.keyword'][0];
+const getCycleId = (v: any): string => v.group_docs.hits.hits?.[0]?.fields['cycle_id.keyword'][0];
 
 export const getLatestCycleIds = async (
   esClient: ElasticsearchClient,


### PR DESCRIPTION
leftovers of `run_id` fields that weren't converted. (and wasn't detected until now because findings BE is not in use yet)