### PR TITLE
Benchmark filtering

### DIFF
--- a/x-pack/plugins/cloud_security_posture/server/routes/benchmarks/benchmarks.test.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/benchmarks/benchmarks.test.ts
@@ -76,6 +76,18 @@ describe('benchmarks API', () => {
       });
     });
 
+    it('expect to find benchmark_filter', async () => {
+      const validatedQuery = benchmarksInputSchema.validate({
+        benchmark_filter: 'my_cis_benchmark',
+      });
+
+      expect(validatedQuery).toMatchObject({
+        page: 1,
+        per_page: DEFAULT_BENCHMARKS_PER_PAGE,
+        benchmark_filter: 'my_cis_benchmark',
+      });
+    });
+
     it('should throw when page field is not a positive integer', async () => {
       expect(() => {
         benchmarksInputSchema.validate({ page: -2 });
@@ -118,6 +130,24 @@ describe('benchmarks API', () => {
         expect(mockAgentPolicyService.list.mock.calls[0][1]).toMatchObject(
           expect.objectContaining({
             kuery: `${PACKAGE_POLICY_SAVED_OBJECT_TYPE}.package.name:myPackage`,
+            page: 1,
+            perPage: 100,
+          })
+        );
+      });
+
+      it('should format request by benchmark_filter', async () => {
+        const mockAgentPolicyService = createPackagePolicyServiceMock();
+
+        await getPackagePolicies(mockSoClient, mockAgentPolicyService, 'myPackage', {
+          page: 1,
+          per_page: 100,
+          benchmark_filter: 'my_cis_benchmark',
+        });
+
+        expect(mockAgentPolicyService.list.mock.calls[0][1]).toMatchObject(
+          expect.objectContaining({
+            kuery: `${PACKAGE_POLICY_SAVED_OBJECT_TYPE}.package.name:myPackage AND ${PACKAGE_POLICY_SAVED_OBJECT_TYPE}.name: *my_cis_benchmark*`,
             page: 1,
             perPage: 100,
           })


### PR DESCRIPTION
- adding support for filter by integration name
* to test it create different agent policies, in each one of them add `cis_kubernetes_benchmark` package and give it a different name. 
then use the next curl commands: 

```
curl --location --request GET 'http://localhost:5601/api/csp/benchmarks?benchmark_filter=my_cis_package' \
--header 'Authorization: Basic ZWxhc3RpYzpjaGFuZ2VtZQ==' \
--header 'kbn-xsrf;'
```